### PR TITLE
LLM polish: tiered describe, compact lists, search ranking, deep links, prompts

### DIFF
--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -2,8 +2,14 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { registerDebugPipelinePrompt } from "./debug-pipeline.js";
 import { registerCreatePipelinePrompt } from "./create-pipeline.js";
+import { registerOptimizeCostsPrompt } from "./optimize-costs.js";
+import { registerSecurityReviewPrompt } from "./security-review.js";
+import { registerOnboardServicePrompt } from "./onboard-service.js";
 
 export function registerAllPrompts(server: McpServer): void {
   registerDebugPipelinePrompt(server);
   registerCreatePipelinePrompt(server);
+  registerOptimizeCostsPrompt(server);
+  registerSecurityReviewPrompt(server);
+  registerOnboardServicePrompt(server);
 }

--- a/src/prompts/onboard-service.ts
+++ b/src/prompts/onboard-service.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function registerOnboardServicePrompt(server: McpServer): void {
+  server.prompt(
+    "onboard-service",
+    "Walk through onboarding a new service into Harness with environments and a deployment pipeline",
+    {
+      serviceName: z.string().describe("Name of the service to onboard"),
+      projectId: z.string().describe("Target project identifier").optional(),
+    },
+    async ({ serviceName, projectId }) => ({
+      messages: [{
+        role: "user" as const,
+        content: {
+          type: "text" as const,
+          text: `Onboard the service "${serviceName}" into Harness with a complete deployment setup.
+
+Steps:
+1. **Check existing**: Call harness_search with query="${serviceName}"${projectId ? ` and project_id="${projectId}"` : ""} to see if this service already exists
+2. **Review patterns**: Call harness_list with resource_type="service"${projectId ? ` and project_id="${projectId}"` : ""} to see existing service patterns in the project
+3. **Environments**: Call harness_list with resource_type="environment"${projectId ? ` and project_id="${projectId}"` : ""} to see available environments
+4. **Connectors**: Call harness_list with resource_type="connector"${projectId ? ` and project_id="${projectId}"` : ""} to see available infrastructure connectors
+5. **Create service**: Generate the service YAML definition following existing patterns
+6. **Create pipeline**: Generate a deployment pipeline YAML for the service with:
+   - Build stage (if applicable)
+   - Deploy to dev/staging/prod environments
+   - Approval gates between staging and prod
+7. **Present for review**: Show all generated YAML before creating anything
+
+Do NOT create any resources until I confirm — present the complete plan first with all YAML definitions.`,
+        },
+      }],
+    }),
+  );
+}

--- a/src/prompts/optimize-costs.ts
+++ b/src/prompts/optimize-costs.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function registerOptimizeCostsPrompt(server: McpServer): void {
+  server.prompt(
+    "optimize-costs",
+    "Analyze cloud cost data and recommend optimizations for a Harness project",
+    {
+      projectId: z.string().describe("Project identifier to analyze costs for").optional(),
+    },
+    async ({ projectId }) => ({
+      messages: [{
+        role: "user" as const,
+        content: {
+          type: "text" as const,
+          text: `Analyze cloud costs and recommend optimizations for this Harness project.
+
+Steps:
+1. Call harness_list with resource_type="cost_recommendation"${projectId ? ` and project_id="${projectId}"` : ""} to get current cost recommendations
+2. Call harness_list with resource_type="cost_anomaly"${projectId ? ` and project_id="${projectId}"` : ""} to identify any cost anomalies
+3. Prioritize findings by potential savings (highest first)
+4. For each recommendation, provide:
+   - **What**: Which resource/service is over-provisioned or idle
+   - **Savings**: Estimated monthly savings
+   - **Action**: Specific steps to realize the savings
+   - **Risk**: Any potential impact of making the change
+
+Present a summary table of top recommendations sorted by savings potential, then detailed breakdowns.`,
+        },
+      }],
+    }),
+  );
+}

--- a/src/prompts/security-review.ts
+++ b/src/prompts/security-review.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function registerSecurityReviewPrompt(server: McpServer): void {
+  server.prompt(
+    "security-review",
+    "Review security issues across Harness resources and suggest remediations",
+    {
+      projectId: z.string().describe("Project identifier to review").optional(),
+      severity: z.string().describe("Comma-separated severity filter (default: critical,high)").optional(),
+    },
+    async ({ projectId, severity }) => {
+      const severityFilter = severity ?? "critical,high";
+      return {
+        messages: [{
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `Perform a security review of Harness resources and provide actionable remediations.
+
+Steps:
+1. Call harness_list with resource_type="security_issue"${projectId ? `, project_id="${projectId}"` : ""}, severity="${severityFilter}" to get current security findings
+2. Call harness_list with resource_type="security_scan" to see recent scan history
+3. Group findings by service/resource
+4. For each finding, provide:
+   - **Severity**: Critical / High / Medium / Low
+   - **Resource**: Which service or component is affected
+   - **Issue**: Description of the vulnerability
+   - **Remediation**: Specific fix with steps
+   - **Priority**: Urgency ranking based on severity and exposure
+
+Present critical issues first with immediate action items, then high-severity items with recommended timeline.`,
+          },
+        }],
+      };
+    },
+  );
+}

--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -37,19 +37,18 @@ export function registerDescribeTool(server: McpServer, registry: Registry): voi
               : undefined,
           });
         } catch (err) {
-          // Resource type not found — return the full describe with an error hint
-          const describe = registry.describe();
+          // Resource type not found — return the compact summary with an error hint
+          const summary = registry.describeSummary();
           return jsonResult({
             error: err instanceof Error ? err.message : String(err),
-            ...describe,
+            ...summary,
           });
         }
       }
 
-      const describe = registry.describe();
-
-      // Filter by toolset if specified
+      // Filter by toolset if specified — use full detail
       if (args.toolset) {
+        const describe = registry.describe();
         const toolsets = describe.toolsets as Record<string, unknown>;
         const filtered = toolsets[args.toolset];
         if (!filtered) {
@@ -61,7 +60,8 @@ export function registerDescribeTool(server: McpServer, registry: Registry): voi
         return jsonResult({ toolset: args.toolset, ...filtered as object });
       }
 
-      return jsonResult(describe);
+      // No-args: return compact summary (~30 tokens per resource type)
+      return jsonResult(registry.describeSummary());
     },
   );
 }

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -4,6 +4,7 @@ import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { toMcpError } from "../utils/errors.js";
+import { compactItems } from "../utils/compact.js";
 
 export function registerListTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
@@ -16,6 +17,7 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
       page: z.number().describe("Page number, 0-indexed").default(0).optional(),
       size: z.number().describe("Page size (max 100)").default(20).optional(),
       search_term: z.string().describe("Filter results by name or keyword").optional(),
+      compact: z.boolean().describe("Strip verbose metadata from list items, keeping only essential fields (default true)").default(true).optional(),
       // Additional filter fields passed through dynamically
       filter_type: z.string().describe("Filter type qualifier").optional(),
       module: z.string().describe("Harness module filter (CD, CI, etc.)").optional(),
@@ -36,6 +38,15 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
     async (args) => {
       try {
         const result = await registry.dispatch(client, args.resource_type, "list", args as Record<string, unknown>);
+
+        // Apply compact mode — strip verbose metadata from list items
+        if (args.compact !== false) {
+          const r = result as { items?: unknown[] };
+          if (r.items && Array.isArray(r.items)) {
+            r.items = compactItems(r.items);
+          }
+        }
+
         return jsonResult(result);
       } catch (err) {
         if (err instanceof Error && err.message.startsWith("Unknown resource_type")) {

--- a/src/utils/compact.ts
+++ b/src/utils/compact.ts
@@ -1,0 +1,55 @@
+/**
+ * Compact item utility — strips verbose metadata from list results,
+ * keeping only fields that are actionable for an LLM.
+ */
+
+/** Timestamp-like key pattern: createdAt, lastModifiedTs, startTime, updatedDate, etc. */
+const TIMESTAMP_PATTERN = /(?:At|Ts|Time|Date)$/;
+
+/** Fields to always keep when compacting list items. */
+const IDENTITY_FIELDS = new Set([
+  "identifier", "name", "displayName", "description", "slug",
+]);
+
+const STATUS_FIELDS = new Set([
+  "status", "state", "enabled", "health",
+]);
+
+const TYPE_FIELDS = new Set([
+  "type", "kind", "category", "module",
+]);
+
+const OWNERSHIP_FIELDS = new Set([
+  "tags", "labels", "owner",
+]);
+
+const ALWAYS_KEEP = new Set(["_deepLink"]);
+
+function isWhitelistedKey(key: string): boolean {
+  return (
+    IDENTITY_FIELDS.has(key) ||
+    STATUS_FIELDS.has(key) ||
+    TYPE_FIELDS.has(key) ||
+    OWNERSHIP_FIELDS.has(key) ||
+    ALWAYS_KEEP.has(key) ||
+    TIMESTAMP_PATTERN.test(key)
+  );
+}
+
+/**
+ * Strip verbose fields from an array of list items.
+ * Keeps identity, status, type, ownership, timestamp, and deep link fields.
+ */
+export function compactItems(items: unknown[]): unknown[] {
+  return items.map((item) => {
+    if (typeof item !== "object" || item === null) return item;
+    const full = item as Record<string, unknown>;
+    const slim: Record<string, unknown> = {};
+    for (const key of Object.keys(full)) {
+      if (isWhitelistedKey(key)) {
+        slim[key] = full[key];
+      }
+    }
+    return slim;
+  });
+}


### PR DESCRIPTION
## Summary
- **Tiered `harness_describe`**: No-args response is now a compact summary (~2K tokens, down from ~8-10K). `resource_type` and `toolset` paths remain full-detail.
- **Compact list mode**: `harness_list` gains a `compact` param (default `true`) that strips verbose metadata from list items, keeping only identity/status/type/ownership/timestamp fields.
- **Search ranking**: `harness_search` results are now ranked by relevance tier (pipeline/service → template/trigger → everything else), with `total_matches` count in the response.
- **Per-item deep links**: List results now attach `_deepLink` to each individual item, not just the wrapper object.
- **3 new prompts**: `optimize-costs`, `security-review`, `onboard-service` (5 prompts total, up from 2).

## Test plan
- [x] `pnpm build` — zero TypeScript errors
- [ ] Verify `harness_describe()` no-args returns compact summary
- [ ] Verify `harness_describe({ resource_type: "pipeline" })` returns full detail (unchanged)
- [ ] Verify `harness_list` compact mode strips verbose fields
- [ ] Verify search results sorted by tier 1 → 2 → 3
- [ ] Verify list items get individual `_deepLink` fields
- [ ] Verify 5 prompts registered via MCP Inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)