### PR TITLE
Add harness_status tool and deep link templates across all toolsets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ async function main(): Promise<void> {
   });
 
   // Register all tools, resources, and prompts
-  registerAllTools(server, registry, client);
+  registerAllTools(server, registry, client, config);
   registerAllResources(server, registry, client, config);
   registerAllPrompts(server);
 

--- a/src/registry/toolsets/access-control.ts
+++ b/src/registry/toolsets/access-control.ts
@@ -23,6 +23,7 @@ export const accessControlToolset: ToolsetDefinition = {
       scope: "account",
       identifierFields: ["user_id"],
       listFilterFields: ["search_term"],
+      deepLinkTemplate: "/ng/account/{accountId}/settings/access-control/users",
       operations: {
         list: {
           method: "POST",
@@ -51,6 +52,7 @@ export const accessControlToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["user_group_id"],
       listFilterFields: ["search_term"],
+      deepLinkTemplate: "/ng/account/{accountId}/settings/access-control/user-groups/{groupIdentifier}",
       operations: {
         list: {
           method: "GET",
@@ -94,6 +96,7 @@ export const accessControlToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["service_account_id"],
       listFilterFields: ["search_term"],
+      deepLinkTemplate: "/ng/account/{accountId}/settings/access-control/service-accounts/{serviceAccountIdentifier}",
       operations: {
         list: {
           method: "GET",
@@ -137,6 +140,7 @@ export const accessControlToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["role_id"],
       listFilterFields: ["search_term"],
+      deepLinkTemplate: "/ng/account/{accountId}/settings/access-control/roles/{roleIdentifier}",
       operations: {
         list: {
           method: "GET",
@@ -210,6 +214,7 @@ export const accessControlToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["resource_group_id"],
       listFilterFields: ["search_term"],
+      deepLinkTemplate: "/ng/account/{accountId}/settings/access-control/resource-groups/{resourceGroupIdentifier}",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/audit.ts
+++ b/src/registry/toolsets/audit.ts
@@ -18,6 +18,7 @@ export const auditToolset: ToolsetDefinition = {
       scope: "account",
       identifierFields: ["audit_id"],
       listFilterFields: ["search_term", "module", "action"],
+      deepLinkTemplate: "/ng/account/{accountId}/settings/audit-trail",
       operations: {
         list: {
           method: "POST",

--- a/src/registry/toolsets/chaos.ts
+++ b/src/registry/toolsets/chaos.ts
@@ -17,6 +17,7 @@ export const chaosToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["experiment_id"],
       listFilterFields: ["search_term"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/chaos/experiments/{experimentId}",
       operations: {
         list: {
           method: "POST",

--- a/src/registry/toolsets/dashboards.ts
+++ b/src/registry/toolsets/dashboards.ts
@@ -26,6 +26,7 @@ export const dashboardsToolset: ToolsetDefinition = {
       scope: "account",
       identifierFields: ["dashboard_id"],
       listFilterFields: ["search_term"],
+      deepLinkTemplate: "/ng/account/{accountId}/dashboards",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/delegates.ts
+++ b/src/registry/toolsets/delegates.ts
@@ -17,6 +17,7 @@ export const delegatesToolset: ToolsetDefinition = {
       toolset: "delegates",
       scope: "account",
       identifierFields: ["delegate_id"],
+      deepLinkTemplate: "/ng/account/{accountId}/settings/resources/delegates",
       operations: {
         list: {
           method: "POST",
@@ -38,6 +39,7 @@ export const delegatesToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["token_name"],
       listFilterFields: ["name", "status"],
+      deepLinkTemplate: "/ng/account/{accountId}/settings/resources/delegates/tokens",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/feature-flags.ts
+++ b/src/registry/toolsets/feature-flags.ts
@@ -49,6 +49,7 @@ export const featureFlagsToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["flag_id"],
       listFilterFields: ["name", "environment"],
+      deepLinkTemplate: "/ng/account/{accountId}/cf/orgs/{orgIdentifier}/projects/{projectIdentifier}/feature-flags/{flagIdentifier}",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/gitops.ts
+++ b/src/registry/toolsets/gitops.ts
@@ -17,6 +17,7 @@ export const gitopsToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["agent_id"],
       listFilterFields: ["search_term", "type"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/gitops/agents/{agentIdentifier}",
       operations: {
         list: {
           method: "GET",
@@ -48,6 +49,7 @@ export const gitopsToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["agent_id", "app_name"],
       listFilterFields: ["search_term"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/gitops/applications/{appName}",
       operations: {
         list: {
           method: "GET",
@@ -93,6 +95,7 @@ export const gitopsToolset: ToolsetDefinition = {
       toolset: "gitops",
       scope: "project",
       identifierFields: ["agent_id", "cluster_id"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/gitops/clusters",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/idp.ts
+++ b/src/registry/toolsets/idp.ts
@@ -26,6 +26,7 @@ export const idpToolset: ToolsetDefinition = {
       scope: "account",
       identifierFields: ["entity_id"],
       listFilterFields: ["kind", "search"],
+      deepLinkTemplate: "/ng/account/{accountId}/idp/catalog",
       operations: {
         list: {
           method: "GET",
@@ -55,6 +56,7 @@ export const idpToolset: ToolsetDefinition = {
       toolset: "idp",
       scope: "account",
       identifierFields: ["scorecard_id"],
+      deepLinkTemplate: "/ng/account/{accountId}/idp/scorecards/{scorecardIdentifier}",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/infrastructure.ts
+++ b/src/registry/toolsets/infrastructure.ts
@@ -23,6 +23,7 @@ export const infrastructureToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["infrastructure_id"],
       listFilterFields: ["environment_id", "search_term"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/environments",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -148,8 +148,9 @@ export const pipelinesToolset: ToolsetDefinition = {
       description: "Automated pipeline triggers (webhook, cron, etc.)",
       toolset: "pipelines",
       scope: "project",
-      identifierFields: ["trigger_id"],
+      identifierFields: ["pipeline_id", "trigger_id"],
       listFilterFields: ["pipeline_id", "search_term"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/pipelines/{pipeline_id}/triggers",
       operations: {
         list: {
           method: "GET",
@@ -201,8 +202,9 @@ export const pipelinesToolset: ToolsetDefinition = {
       description: "Reusable runtime input sets for pipelines",
       toolset: "pipelines",
       scope: "project",
-      identifierFields: ["input_set_id"],
+      identifierFields: ["pipeline_id", "input_set_id"],
       listFilterFields: ["pipeline_id"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/pipelines/{pipeline_id}/input-sets",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/pull-requests.ts
+++ b/src/registry/toolsets/pull-requests.ts
@@ -16,6 +16,7 @@ export const pullRequestsToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["repo_id", "pr_number"],
       listFilterFields: ["state", "query"],
+      deepLinkTemplate: "/ng/account/{accountId}/module/code/orgs/{orgIdentifier}/projects/{projectIdentifier}/repos/{repoIdentifier}/pull-requests/{prNumber}",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/registries.ts
+++ b/src/registry/toolsets/registries.ts
@@ -16,6 +16,7 @@ export const registriesToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["registry_id"],
       listFilterFields: ["search", "type"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/registries/{registryIdentifier}",
       operations: {
         list: {
           method: "GET",
@@ -46,6 +47,7 @@ export const registriesToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["registry_id", "artifact_id"],
       listFilterFields: ["search"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/registries/{registryIdentifier}/artifacts/{artifactIdentifier}",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/repositories.ts
+++ b/src/registry/toolsets/repositories.ts
@@ -16,6 +16,7 @@ export const repositoriesToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["repo_id"],
       listFilterFields: ["query", "sort"],
+      deepLinkTemplate: "/ng/account/{accountId}/module/code/orgs/{orgIdentifier}/projects/{projectIdentifier}/repos/{repoIdentifier}",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/scs.ts
+++ b/src/registry/toolsets/scs.ts
@@ -17,6 +17,7 @@ export const scsToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["artifact_id"],
       listFilterFields: ["search"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/supply-chain/artifacts/{artifactId}",
       operations: {
         list: {
           method: "GET",
@@ -46,6 +47,7 @@ export const scsToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["repo_id"],
       listFilterFields: ["search"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/supply-chain/repositories/{repoId}",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/secrets.ts
+++ b/src/registry/toolsets/secrets.ts
@@ -23,6 +23,7 @@ export const secretsToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["secret_id"],
       listFilterFields: ["search_term", "type"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/setup/resources/secrets/{secretIdentifier}",
       operations: {
         list: {
           method: "POST",

--- a/src/registry/toolsets/sto.ts
+++ b/src/registry/toolsets/sto.ts
@@ -18,6 +18,7 @@ export const stoToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["issue_id"],
       listFilterFields: ["search", "severity"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/sto/issues/{issueId}",
       operations: {
         list: {
           method: "GET",
@@ -47,6 +48,7 @@ export const stoToolset: ToolsetDefinition = {
       toolset: "sto",
       scope: "project",
       identifierFields: ["exemption_id"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/sto/exemptions",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/templates.ts
+++ b/src/registry/toolsets/templates.ts
@@ -26,6 +26,7 @@ export const templatesToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["template_id"],
       listFilterFields: ["search_term", "template_type"],
+      deepLinkTemplate: "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/setup/resources/templates",
       operations: {
         list: {
           method: "POST",

--- a/src/tools/harness-status.ts
+++ b/src/tools/harness-status.ts
@@ -1,0 +1,204 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Registry } from "../registry/index.js";
+import type { HarnessClient } from "../client/harness-client.js";
+import type { Config } from "../config.js";
+import { jsonResult, errorResult } from "../utils/response-formatter.js";
+import { buildDeepLink } from "../utils/deep-links.js";
+import { toMcpError } from "../utils/errors.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("status");
+
+interface ExecutionItem {
+  pipelineIdentifier?: string;
+  planExecutionId?: string;
+  name?: string;
+  status?: string;
+  startTs?: number;
+  endTs?: number;
+  [key: string]: unknown;
+}
+
+interface ListResult {
+  items?: ExecutionItem[];
+  total?: number;
+  [key: string]: unknown;
+}
+
+function summarizeExecution(
+  exec: ExecutionItem,
+  baseUrl: string,
+  accountId: string,
+  orgId: string,
+  projectId: string,
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {
+    execution_id: exec.planExecutionId,
+    pipeline: exec.pipelineIdentifier,
+    name: exec.name,
+    status: exec.status,
+    started_at: exec.startTs ? new Date(exec.startTs).toISOString() : undefined,
+    ended_at: exec.endTs ? new Date(exec.endTs).toISOString() : undefined,
+  };
+
+  if (exec.planExecutionId && exec.pipelineIdentifier) {
+    try {
+      summary._deepLink = buildDeepLink(baseUrl, accountId,
+        "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/pipelines/{pipelineIdentifier}/executions/{planExecutionId}/pipeline",
+        {
+          orgIdentifier: orgId,
+          projectIdentifier: projectId,
+          pipelineIdentifier: exec.pipelineIdentifier,
+          planExecutionId: exec.planExecutionId,
+        },
+      );
+    } catch {
+      // non-critical
+    }
+  }
+
+  return summary;
+}
+
+export function registerStatusTool(
+  server: McpServer,
+  registry: Registry,
+  client: HarnessClient,
+  config: Config,
+): void {
+  server.tool(
+    "harness_status",
+    "Get a live project health overview: recent failed executions, currently running executions, and recent deployment activity. Ideal first question: 'what's happening in my project right now?'",
+    {
+      org_id: z.string().describe("Organization identifier (overrides default)").optional(),
+      project_id: z.string().describe("Project identifier (overrides default)").optional(),
+      limit: z.number().describe("Max items per section (default 5, max 20)").default(5).optional(),
+    },
+    async (args) => {
+      try {
+        const orgId = args.org_id ?? config.HARNESS_DEFAULT_ORG_ID;
+        const projectId = args.project_id ?? config.HARNESS_DEFAULT_PROJECT_ID ?? "";
+        const limit = Math.min(args.limit ?? 5, 20);
+
+        const baseInput: Record<string, unknown> = {
+          org_id: orgId,
+          project_id: projectId,
+          size: limit,
+          page: 0,
+        };
+
+        log.info("Fetching project status", { orgId, projectId, limit });
+
+        // 3 parallel dispatches: failed, running, recent activity
+        const [failedResult, runningResult, recentResult] = await Promise.allSettled([
+          registry.dispatch(client, "execution", "list", {
+            ...baseInput,
+            status: "Failed",
+          }),
+          registry.dispatch(client, "execution", "list", {
+            ...baseInput,
+            status: "Running",
+          }),
+          registry.dispatch(client, "execution", "list", {
+            ...baseInput,
+            size: Math.min(limit * 2, 20),
+          }),
+        ]);
+
+        // Extract results with graceful degradation
+        const failed = failedResult.status === "fulfilled"
+          ? (failedResult.value as ListResult)
+          : null;
+        const running = runningResult.status === "fulfilled"
+          ? (runningResult.value as ListResult)
+          : null;
+        const recent = recentResult.status === "fulfilled"
+          ? (recentResult.value as ListResult)
+          : null;
+
+        if (failedResult.status === "rejected") {
+          log.warn("Failed to fetch failed executions", { error: String(failedResult.reason) });
+        }
+        if (runningResult.status === "rejected") {
+          log.warn("Failed to fetch running executions", { error: String(runningResult.reason) });
+        }
+        if (recentResult.status === "rejected") {
+          log.warn("Failed to fetch recent executions", { error: String(recentResult.reason) });
+        }
+
+        const failedItems = (failed?.items ?? []).map((e) =>
+          summarizeExecution(e, config.HARNESS_BASE_URL, config.HARNESS_ACCOUNT_ID, orgId, projectId),
+        );
+        const runningItems = (running?.items ?? []).map((e) =>
+          summarizeExecution(e, config.HARNESS_BASE_URL, config.HARNESS_ACCOUNT_ID, orgId, projectId),
+        );
+        const recentItems = (recent?.items ?? []).map((e) =>
+          summarizeExecution(e, config.HARNESS_BASE_URL, config.HARNESS_ACCOUNT_ID, orgId, projectId),
+        );
+
+        // Compute health
+        const totalFailed = failed?.total ?? failedItems.length;
+        const totalRunning = running?.total ?? runningItems.length;
+        const totalRecent = recent?.total ?? recentItems.length;
+
+        let health: "healthy" | "degraded" | "failing";
+        if (totalFailed === 0) {
+          health = "healthy";
+        } else if (totalRecent > 0 && totalFailed < totalRecent) {
+          health = "degraded";
+        } else {
+          health = "failing";
+        }
+
+        // Build project-level deployments deep link
+        let deploymentsLink: string | undefined;
+        try {
+          deploymentsLink = buildDeepLink(
+            config.HARNESS_BASE_URL,
+            config.HARNESS_ACCOUNT_ID,
+            "/ng/account/{accountId}/home/orgs/{orgIdentifier}/projects/{projectIdentifier}/deployments",
+            { orgIdentifier: orgId, projectIdentifier: projectId },
+          );
+        } catch {
+          // non-critical
+        }
+
+        // Collect errors from rejected promises
+        const errors: Record<string, string> = {};
+        if (failedResult.status === "rejected") errors.failed = String(failedResult.reason);
+        if (runningResult.status === "rejected") errors.running = String(runningResult.reason);
+        if (recentResult.status === "rejected") errors.recent = String(recentResult.reason);
+
+        const status: Record<string, unknown> = {
+          project: {
+            org: orgId,
+            project: projectId,
+            url: deploymentsLink,
+          },
+          failed_executions: failedItems,
+          running_executions: runningItems,
+          recent_activity: recentItems,
+          summary: {
+            total_failed: totalFailed,
+            total_running: totalRunning,
+            total_recent: totalRecent,
+            health,
+          },
+          _deepLink: deploymentsLink,
+        };
+
+        if (Object.keys(errors).length > 0) {
+          status._errors = errors;
+        }
+
+        return jsonResult(status);
+      } catch (err) {
+        if (err instanceof Error) {
+          return errorResult(err.message);
+        }
+        throw toMcpError(err);
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
+import type { Config } from "../config.js";
 
 import { registerListTool } from "./harness-list.js";
 import { registerGetTool } from "./harness-get.js";
@@ -11,8 +12,9 @@ import { registerExecuteTool } from "./harness-execute.js";
 import { registerDiagnoseTool } from "./harness-diagnose.js";
 import { registerSearchTool } from "./harness-search.js";
 import { registerDescribeTool } from "./harness-describe.js";
+import { registerStatusTool } from "./harness-status.js";
 
-export function registerAllTools(server: McpServer, registry: Registry, client: HarnessClient): void {
+export function registerAllTools(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   registerListTool(server, registry, client);
   registerGetTool(server, registry, client);
   registerCreateTool(server, registry, client);
@@ -22,4 +24,5 @@ export function registerAllTools(server: McpServer, registry: Registry, client: 
   registerDiagnoseTool(server, registry, client);
   registerSearchTool(server, registry, client);
   registerDescribeTool(server, registry);
+  registerStatusTool(server, registry, client, config);
 }


### PR DESCRIPTION
## Summary
- **New `harness_status` tool**: Live project health overview — fetches failed, running, and recent executions in parallel, classifies project health as healthy/degraded/failing, and attaches deep links to every execution. Ideal first question: "what's happening in my project right now?"
- **Deep link templates for 18 toolsets**: Added `deepLinkTemplate` to all resource types that were missing them — access-control (users, user-groups, service-accounts, roles, resource-groups), audit, chaos, dashboards, delegates, feature-flags, gitops (agents, apps, clusters), idp (catalog, scorecards), infrastructure, pull-requests, registries, repositories, scs, secrets, sto, templates
- **Fix trigger/input_set identifierFields**: Added `pipeline_id` to `identifierFields` for trigger and input_set resources (required for correct deep link resolution)

## Test plan
- [x] `pnpm build` — zero TypeScript errors
- [ ] Verify `harness_status` returns failed/running/recent sections with health classification
- [ ] Verify deep links render correctly for newly covered toolsets (e.g. secrets, templates, feature-flags)
- [ ] Verify trigger/input_set deep links resolve correctly with pipeline_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)