### PR TITLE
Add Streamable HTTP transport and npm publishing support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ HARNESS_API_TIMEOUT_MS=30000
 HARNESS_MAX_RETRIES=3
 LOG_LEVEL=info
 
+# HTTP transport only — ignored in stdio mode
+PORT=3000
+
 # Toolset filtering — comma-separated list of enabled toolsets
 # If unset, all toolsets are enabled
 # Available: pipelines,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto

--- a/package.json
+++ b/package.json
@@ -1,21 +1,44 @@
 {
-  "name": "harness-mcp-server",
+  "name": "harness-poc-mcp-server",
   "version": "1.0.0",
-  "description": "MCP server for Harness.io CI/CD platform — 9 consolidated tools with registry-based dispatch",
+  "description": "MCP server for Harness.io CI/CD platform — 10 consolidated tools with registry-based dispatch",
   "type": "module",
   "main": "build/index.js",
   "bin": {
-    "harness-mcp-server": "build/index.js"
+    "harness-poc-mcp-server": "build/index.js"
   },
+  "files": [
+    "build/"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node build/index.js stdio",
+    "start:http": "node build/index.js http",
     "inspect": "npx @modelcontextprotocol/inspector node build/index.js stdio",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "pnpm build"
   },
+  "keywords": [
+    "mcp",
+    "harness",
+    "harness-io",
+    "ci-cd",
+    "model-context-protocol",
+    "ai-agent",
+    "devops"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thisrohangupta/harness-poc-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/thisrohangupta/harness-poc-mcp/issues"
+  },
+  "homepage": "https://github.com/thisrohangupta/harness-poc-mcp#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "zod": "^3.24.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,162 @@
 #!/usr/bin/env node
 
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { loadConfig } from "./config.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { loadConfig, type Config } from "./config.js";
 import { setLogLevel, createLogger } from "./utils/logger.js";
 import { HarnessClient } from "./client/harness-client.js";
 import { Registry } from "./registry/index.js";
 import { registerAllTools } from "./tools/index.js";
 import { registerAllResources } from "./resources/index.js";
 import { registerAllPrompts } from "./prompts/index.js";
+import { parseArgs } from "./utils/cli.js";
 
 const log = createLogger("main");
 
+/**
+ * Create a fully-configured MCP server instance with all tools, resources, and prompts.
+ */
+function createHarnessServer(config: Config): McpServer {
+  const client = new HarnessClient(config);
+  const registry = new Registry(config);
+
+  const server = new McpServer({
+    name: "harness-mcp-server",
+    version: "1.0.0",
+  });
+
+  registerAllTools(server, registry, client, config);
+  registerAllResources(server, registry, client, config);
+  registerAllPrompts(server);
+
+  return server;
+}
+
+/**
+ * Start the server in stdio mode — single persistent connection.
+ */
+async function startStdio(config: Config): Promise<void> {
+  const server = createHarnessServer(config);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  log.info("harness-mcp-server connected via stdio");
+}
+
+/**
+ * Start the server in HTTP mode — stateless, one server+transport per POST request.
+ */
+async function startHttp(config: Config, port: number): Promise<void> {
+  const CORS_HEADERS: Record<string, string> = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, mcp-session-id",
+  };
+
+  const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? "/";
+
+    // Health check
+    if (url === "/health" && req.method === "GET") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+
+    // Only handle /mcp
+    if (url !== "/mcp") {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+      return;
+    }
+
+    // CORS preflight
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, CORS_HEADERS);
+      res.end();
+      return;
+    }
+
+    // Stateless mode only supports POST
+    if (req.method !== "POST") {
+      res.writeHead(405, {
+        ...CORS_HEADERS,
+        Allow: "POST, OPTIONS",
+        "Content-Type": "application/json",
+      });
+      res.end(JSON.stringify({ error: "Method not allowed. Use POST for stateless MCP." }));
+      return;
+    }
+
+    // Set CORS headers on all POST responses
+    for (const [key, value] of Object.entries(CORS_HEADERS)) {
+      res.setHeader(key, value);
+    }
+
+    try {
+      const body = await readBody(req);
+      const parsedBody: unknown = JSON.parse(body);
+
+      // Create a fresh server + transport per request (stateless)
+      const server = createHarnessServer(config);
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined, // stateless mode
+      });
+
+      await server.connect(transport);
+      await transport.handleRequest(req, res, parsedBody);
+
+      // Close after handling — stateless, no persistent session
+      await transport.close();
+      await server.close();
+    } catch (err) {
+      log.error("Error handling MCP request", { error: String(err) });
+      if (!res.headersSent) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Invalid request" }));
+      }
+    }
+  });
+
+  // Graceful shutdown
+  const shutdown = (): void => {
+    log.info("Shutting down HTTP server...");
+    httpServer.close(() => {
+      log.info("HTTP server closed");
+      process.exit(0);
+    });
+    // Force exit after 5s if connections linger
+    setTimeout(() => process.exit(1), 5000).unref();
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  httpServer.listen(port, () => {
+    log.info(`harness-mcp-server listening on http://localhost:${port}`);
+    log.info(`  POST /mcp    — MCP endpoint (stateless)`);
+    log.info(`  GET  /health — Health check`);
+  });
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    req.on("error", reject);
+  });
+}
+
 async function main(): Promise<void> {
-  // Load and validate config
   const config = loadConfig();
   setLogLevel(config.LOG_LEVEL);
 
+  const { transport, port } = parseArgs();
+
   log.info("Starting harness-mcp-server", {
+    transport,
     baseUrl: config.HARNESS_BASE_URL,
     accountId: config.HARNESS_ACCOUNT_ID,
     defaultOrg: config.HARNESS_DEFAULT_ORG_ID,
@@ -25,31 +164,10 @@ async function main(): Promise<void> {
     toolsets: config.HARNESS_TOOLSETS ?? "(all)",
   });
 
-  // Initialize client and registry
-  const client = new HarnessClient(config);
-  const registry = new Registry(config);
-
-  // Create MCP server
-  const server = new McpServer({
-    name: "harness-mcp-server",
-    version: "1.0.0",
-  });
-
-  // Register all tools, resources, and prompts
-  registerAllTools(server, registry, client, config);
-  registerAllResources(server, registry, client, config);
-  registerAllPrompts(server);
-
-  // Determine transport from CLI args
-  const transportArg = process.argv[2] ?? "stdio";
-
-  if (transportArg === "stdio") {
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
-    log.info("harness-mcp-server connected via stdio");
+  if (transport === "stdio") {
+    await startStdio(config);
   } else {
-    log.error(`Unknown transport: ${transportArg}. Supported: stdio`);
-    process.exit(1);
+    await startHttp(config, port);
   }
 }
 

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -1,0 +1,73 @@
+/**
+ * CLI argument parsing for transport selection and port configuration.
+ */
+
+export type Transport = "stdio" | "http";
+
+export interface CliArgs {
+  transport: Transport;
+  port: number;
+}
+
+const VALID_TRANSPORTS = new Set<string>(["stdio", "http"]);
+const DEFAULT_PORT = 3000;
+const MIN_PORT = 1;
+const MAX_PORT = 65535;
+
+/**
+ * Parse CLI arguments for transport mode and port.
+ *
+ * Usage:
+ *   node build/index.js [stdio|http] [--port <number>]
+ *
+ * - Transport defaults to "stdio" if not specified.
+ * - Port defaults to --port flag, then PORT env var, then 3000.
+ * - Throws on unknown transport names.
+ */
+export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
+  const transport = parseTransport(argv);
+  const port = parsePort(argv);
+  return { transport, port };
+}
+
+function parseTransport(argv: string[]): Transport {
+  // First positional arg that isn't a flag or flag value
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--port") {
+      i++; // skip the value after --port
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+
+    if (!VALID_TRANSPORTS.has(arg)) {
+      throw new Error(
+        `Unknown transport: "${arg}". Supported: stdio, http`,
+      );
+    }
+    return arg as Transport;
+  }
+  return "stdio";
+}
+
+function parsePort(argv: string[]): number {
+  // Check --port flag first
+  const portFlagIndex = argv.indexOf("--port");
+  if (portFlagIndex !== -1 && portFlagIndex + 1 < argv.length) {
+    const parsed = Number(argv[portFlagIndex + 1]);
+    if (isValidPort(parsed)) return parsed;
+  }
+
+  // Fall back to PORT env var
+  const envPort = process.env.PORT;
+  if (envPort !== undefined) {
+    const parsed = Number(envPort);
+    if (isValidPort(parsed)) return parsed;
+  }
+
+  return DEFAULT_PORT;
+}
+
+function isValidPort(n: number): boolean {
+  return Number.isInteger(n) && n >= MIN_PORT && n <= MAX_PORT;
+}

--- a/tests/utils/cli.test.ts
+++ b/tests/utils/cli.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { parseArgs } from "../../src/utils/cli.js";
+
+describe("parseArgs", () => {
+  let originalPort: string | undefined;
+
+  beforeEach(() => {
+    originalPort = process.env.PORT;
+    delete process.env.PORT;
+  });
+
+  afterEach(() => {
+    if (originalPort !== undefined) {
+      process.env.PORT = originalPort;
+    } else {
+      delete process.env.PORT;
+    }
+  });
+
+  it("defaults to stdio transport and port 3000", () => {
+    const args = parseArgs([]);
+    expect(args.transport).toBe("stdio");
+    expect(args.port).toBe(3000);
+  });
+
+  it("parses http transport", () => {
+    const args = parseArgs(["http"]);
+    expect(args.transport).toBe("http");
+  });
+
+  it("parses stdio transport explicitly", () => {
+    const args = parseArgs(["stdio"]);
+    expect(args.transport).toBe("stdio");
+  });
+
+  it("parses --port flag", () => {
+    const args = parseArgs(["http", "--port", "8080"]);
+    expect(args.transport).toBe("http");
+    expect(args.port).toBe(8080);
+  });
+
+  it("parses --port before transport", () => {
+    const args = parseArgs(["--port", "9090", "http"]);
+    expect(args.transport).toBe("http");
+    expect(args.port).toBe(9090);
+  });
+
+  it("falls back to PORT env var when --port not specified", () => {
+    process.env.PORT = "4000";
+    const args = parseArgs(["http"]);
+    expect(args.port).toBe(4000);
+  });
+
+  it("--port flag takes precedence over PORT env var", () => {
+    process.env.PORT = "4000";
+    const args = parseArgs(["http", "--port", "5000"]);
+    expect(args.port).toBe(5000);
+  });
+
+  it("ignores invalid --port value and falls back to default", () => {
+    const args = parseArgs(["http", "--port", "not-a-number"]);
+    expect(args.port).toBe(3000);
+  });
+
+  it("ignores out-of-range port (0) and falls back to default", () => {
+    const args = parseArgs(["http", "--port", "0"]);
+    expect(args.port).toBe(3000);
+  });
+
+  it("ignores out-of-range port (99999) and falls back to default", () => {
+    const args = parseArgs(["http", "--port", "99999"]);
+    expect(args.port).toBe(3000);
+  });
+
+  it("ignores fractional port and falls back to default", () => {
+    const args = parseArgs(["http", "--port", "3000.5"]);
+    expect(args.port).toBe(3000);
+  });
+
+  it("throws on unknown transport", () => {
+    expect(() => parseArgs(["grpc"])).toThrow(
+      'Unknown transport: "grpc". Supported: stdio, http',
+    );
+  });
+
+  it("accepts port 1 (minimum)", () => {
+    const args = parseArgs(["--port", "1"]);
+    expect(args.port).toBe(1);
+  });
+
+  it("accepts port 65535 (maximum)", () => {
+    const args = parseArgs(["--port", "65535"]);
+    expect(args.port).toBe(65535);
+  });
+});


### PR DESCRIPTION
## Summary

- Add **Streamable HTTP transport** (`node build/index.js http --port 8080`) using the SDK's `StreamableHTTPServerTransport` in stateless mode — zero new dependencies (`node:http` only)
- Prepare package for **npm publishing** as `harness-poc-mcp-server` with `npx` zero-install support
- Extract CLI arg parsing into testable `src/utils/cli.ts` module with 14 unit tests

## Changes

| File | Action | What |
|------|--------|------|
| `src/utils/cli.ts` | NEW | CLI parser: `stdio`/`http` transport, `--port` flag, `PORT` env fallback |
| `src/index.ts` | MODIFY | `createHarnessServer()` helper, HTTP branch with `POST /mcp`, `GET /health`, CORS, graceful shutdown |
| `package.json` | MODIFY | Rename to `harness-poc-mcp-server`, add `files`, `bin`, `prepublishOnly`, metadata |
| `.env.example` | MODIFY | Add `PORT=3000` for HTTP transport |
| `tests/utils/cli.test.ts` | NEW | 14 tests for arg parsing, edge cases, error handling |
| `README.md` | MODIFY | HTTP usage, `npx` instructions, endpoint table, curl examples |

## HTTP Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/mcp` | `POST` | MCP JSON-RPC endpoint (stateless) |
| `/mcp` | `OPTIONS` | CORS preflight |
| `/health` | `GET` | Health check — `{ "status": "ok" }` |

## Test plan

- [x] `pnpm build` — zero TypeScript errors
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 63/63 tests pass (6 test files, including 14 new CLI tests)
- [ ] `node build/index.js stdio` — still works as before
- [ ] `node build/index.js http --port 3000` — starts HTTP server
- [ ] `curl http://localhost:3000/health` — returns 200
- [ ] `curl -X POST http://localhost:3000/mcp` with MCP initialize payload — returns valid response

🤖 Generated with [Claude Code](https://claude.com/claude-code)