### PR TITLE
Expose Harness JSON Schemas as MCP resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,9 @@ The server exposes 10 MCP tools. Every tool accepts `org_id` and `project_id` as
 | `pipeline:///{pipelineId}` | Pipeline YAML definition | `application/x-yaml` |
 | `pipeline:///{orgId}/{projectId}/{pipelineId}` | Pipeline YAML (with explicit scope) | `application/x-yaml` |
 | `executions:///recent` | Last 10 pipeline execution summaries | `application/json` |
+| `schema:///pipeline` | Harness pipeline JSON Schema | `application/schema+json` |
+| `schema:///template` | Harness template JSON Schema | `application/schema+json` |
+| `schema:///trigger` | Harness trigger JSON Schema | `application/schema+json` |
 
 ## Toolset Filtering
 

--- a/src/prompts/create-pipeline.ts
+++ b/src/prompts/create-pipeline.ts
@@ -19,11 +19,12 @@ export function registerCreatePipelinePrompt(server: McpServer): void {
 ${description}
 
 Steps:
-1. First call harness_describe with resource_type="pipeline" to understand the pipeline schema
-2. If helpful, call harness_list with resource_type="pipeline"${projectId ? ` and project_id="${projectId}"` : ""} to see existing pipeline patterns
-3. Also check available connectors (harness_list resource_type="connector"), services (harness_list resource_type="service"), and environments (harness_list resource_type="environment")
-4. Generate the pipeline YAML
-5. Present the YAML for review before creating
+1. Read the pipeline JSON Schema resource (schema:///pipeline) to understand the required pipeline structure and fields
+2. Call harness_describe with resource_type="pipeline" to understand available operations
+3. If helpful, call harness_list with resource_type="pipeline"${projectId ? ` and project_id="${projectId}"` : ""} to see existing pipeline patterns
+4. Also check available connectors (harness_list resource_type="connector"), services (harness_list resource_type="service"), and environments (harness_list resource_type="environment")
+5. Generate the pipeline YAML conforming to the schema
+6. Present the YAML for review before creating
 
 Do NOT create the pipeline until I confirm — just show me the YAML first.`,
         },

--- a/src/resources/harness-schema.ts
+++ b/src/resources/harness-schema.ts
@@ -1,0 +1,77 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("resource:harness-schema");
+
+const VALID_SCHEMAS = ["pipeline", "template", "trigger"] as const;
+type SchemaName = (typeof VALID_SCHEMAS)[number];
+
+const SCHEMA_BASE_URL =
+  "https://raw.githubusercontent.com/harness/harness-schema/main/v0";
+
+function buildSchemaUrl(name: SchemaName): string {
+  return `${SCHEMA_BASE_URL}/${name}.json`;
+}
+
+const schemaCache = new Map<SchemaName, string>();
+
+async function fetchSchema(name: SchemaName): Promise<string> {
+  const cached = schemaCache.get(name);
+  if (cached) {
+    log.debug("Returning cached schema", { name });
+    return cached;
+  }
+
+  const url = buildSchemaUrl(name);
+  log.info("Fetching schema from GitHub", { name, url });
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch schema '${name}': HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const text = await response.text();
+  schemaCache.set(name, text);
+  return text;
+}
+
+function isValidSchemaName(name: string): name is SchemaName {
+  return (VALID_SCHEMAS as readonly string[]).includes(name);
+}
+
+export function registerHarnessSchemaResource(server: McpServer): void {
+  server.resource(
+    "harness-schema",
+    "schema:///{schemaName}",
+    {
+      description: `Harness JSON Schema definitions. Valid schema names: ${VALID_SCHEMAS.join(", ")}. Use these to understand the required body format for harness_create.`,
+      mimeType: "application/schema+json",
+    },
+    async (uri) => {
+      const schemaName = uri.pathname.replace(/^\/+/, "");
+
+      if (!isValidSchemaName(schemaName)) {
+        throw new Error(
+          `Unknown schema '${schemaName}'. Valid schemas: ${VALID_SCHEMAS.join(", ")}`,
+        );
+      }
+
+      const text = await fetchSchema(schemaName);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/schema+json",
+            text,
+          },
+        ],
+      };
+    },
+  );
+}
+
+// Exported for testing
+export { VALID_SCHEMAS, buildSchemaUrl, isValidSchemaName, schemaCache };

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -5,8 +5,10 @@ import type { Config } from "../config.js";
 
 import { registerPipelineYamlResource } from "./pipeline-yaml.js";
 import { registerExecutionSummaryResource } from "./execution-summary.js";
+import { registerHarnessSchemaResource } from "./harness-schema.js";
 
 export function registerAllResources(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   registerPipelineYamlResource(server, registry, client, config);
   registerExecutionSummaryResource(server, registry, client, config);
+  registerHarnessSchemaResource(server);
 }

--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -8,7 +8,7 @@ import { toMcpError } from "../utils/errors.js";
 export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
     "harness_create",
-    "Create a new Harness resource. Requires confirmation=true to proceed.",
+    "Create a new Harness resource. Requires confirmation=true to proceed. For pipelines, templates, and triggers — read the schema resource first (e.g. schema:///pipeline) to understand the required body format.",
     {
       resource_type: z.string().describe("The type of resource to create (e.g. pipeline, service, environment, connector, trigger)"),
       body: z.record(z.unknown()).describe("The resource definition body (varies by resource type — typically the YAML or JSON spec)"),

--- a/tests/resources/harness-schema.test.ts
+++ b/tests/resources/harness-schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  VALID_SCHEMAS,
+  buildSchemaUrl,
+  isValidSchemaName,
+  schemaCache,
+} from "../../src/resources/harness-schema.js";
+
+describe("harness-schema resource", () => {
+  beforeEach(() => {
+    schemaCache.clear();
+  });
+
+  describe("VALID_SCHEMAS", () => {
+    it("contains pipeline, template, and trigger", () => {
+      expect(VALID_SCHEMAS).toEqual(["pipeline", "template", "trigger"]);
+    });
+  });
+
+  describe("buildSchemaUrl", () => {
+    it("builds correct URL for pipeline", () => {
+      expect(buildSchemaUrl("pipeline")).toBe(
+        "https://raw.githubusercontent.com/harness/harness-schema/main/v0/pipeline.json",
+      );
+    });
+
+    it("builds correct URL for template", () => {
+      expect(buildSchemaUrl("template")).toBe(
+        "https://raw.githubusercontent.com/harness/harness-schema/main/v0/template.json",
+      );
+    });
+
+    it("builds correct URL for trigger", () => {
+      expect(buildSchemaUrl("trigger")).toBe(
+        "https://raw.githubusercontent.com/harness/harness-schema/main/v0/trigger.json",
+      );
+    });
+  });
+
+  describe("isValidSchemaName", () => {
+    it("returns true for valid schema names", () => {
+      expect(isValidSchemaName("pipeline")).toBe(true);
+      expect(isValidSchemaName("template")).toBe(true);
+      expect(isValidSchemaName("trigger")).toBe(true);
+    });
+
+    it("returns false for invalid schema names", () => {
+      expect(isValidSchemaName("invalid")).toBe(false);
+      expect(isValidSchemaName("")).toBe(false);
+      expect(isValidSchemaName("Pipeline")).toBe(false);
+      expect(isValidSchemaName("connector")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `schema:///pipeline`, `schema:///template`, and `schema:///trigger` MCP resources that fetch JSON Schema definitions from the [harness/harness-schema](https://github.com/harness/harness-schema) GitHub repo
- AI clients can now read the schema on-demand before calling `harness_create`, reducing malformed payloads and API errors
- Updated `harness_create` tool description and `create-pipeline` prompt to reference schema resources

## Changes

| File | Action |
|------|--------|
| `src/resources/harness-schema.ts` | NEW — resource provider with in-memory caching and validation |
| `src/resources/index.ts` | MODIFY — register new resource |
| `src/tools/harness-create.ts` | MODIFY — updated description to mention schemas |
| `src/prompts/create-pipeline.ts` | MODIFY — added schema read step |
| `tests/resources/harness-schema.test.ts` | NEW — unit tests |
| `README.md` | MODIFY — added schema resources to table |

## Test plan

- [x] `pnpm build` — zero TypeScript errors
- [x] `pnpm test` — all 78 tests pass (6 new)
- [ ] MCP Inspector: read `schema:///pipeline` — returns JSON Schema content
- [ ] MCP Inspector: read `schema:///invalid` — returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)