### PR TITLE
Trim tool descriptions, add search to harness_describe

### DIFF
--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -10,6 +10,7 @@ export function registerDescribeTool(server: McpServer, registry: Registry): voi
     {
       resource_type: z.string().describe("Get details for a specific resource type").optional(),
       toolset: z.string().describe("Filter to a specific toolset (e.g. pipelines, services)").optional(),
+      search_term: z.string().describe("Search for resource types by keyword (matches type name, display name, toolset, description)").optional(),
     },
     async (args) => {
       if (args.resource_type) {
@@ -44,6 +45,19 @@ export function registerDescribeTool(server: McpServer, registry: Registry): voi
             ...summary,
           });
         }
+      }
+
+      // Search by keyword
+      if (args.search_term) {
+        const results = registry.searchResources(args.search_term);
+        return jsonResult({
+          search_term: args.search_term,
+          total_results: results.length,
+          resource_types: results,
+          hint: results.length > 0
+            ? "Call harness_describe with resource_type='<type>' for full details on a specific match."
+            : "No matches found. Try a broader term, or call harness_describe with no arguments to see all resource types.",
+        });
       }
 
       // Filter by toolset if specified — use full detail

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -8,7 +8,7 @@ import { toMcpError } from "../utils/errors.js";
 export function registerGetTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
     "harness_get",
-    `Get a specific Harness resource by ID. Available resource_types: ${registry.getAllResourceTypes().join(", ")}`,
+    "Get a specific Harness resource by ID. Call harness_describe to discover available resource_types, or harness_describe with search_term to find specific ones.",
     {
       resource_type: z.string().describe("The type of resource to get (e.g. pipeline, service, environment)"),
       resource_id: z.string().describe("The primary identifier of the resource"),

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -9,7 +9,7 @@ import { compactItems } from "../utils/compact.js";
 export function registerListTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
     "harness_list",
-    `List Harness resources by type with filtering and pagination. Available resource_types: ${registry.getAllResourceTypes().join(", ")}`,
+    "List Harness resources by type with filtering and pagination. Call harness_describe to discover available resource_types, or harness_describe with search_term to find specific ones.",
     {
       resource_type: z.string().describe("The type of resource to list (e.g. pipeline, service, environment, connector)"),
       org_id: z.string().describe("Organization identifier (overrides default)").optional(),


### PR DESCRIPTION
## Summary
- **Remove inline resource type lists** from `harness_list` and `harness_get` tool descriptions — eliminates ~111 type names from the MCP schema sent on every `tools/list` call, significantly reducing LLM token overhead
- **Add `search_term` parameter** to `harness_describe` — agents can now find resource types by keyword instead of browsing the full summary
- **Add `searchResources(query)` method** to `Registry` — scored substring matching against type key, display name, toolset, and description

## Test plan
- [x] `pnpm build` — compiles cleanly
- [x] `pnpm test` — all 78 existing tests pass
- [ ] `pnpm inspect` → call `tools/list` → confirm `harness_list` and `harness_get` descriptions no longer contain resource type dump
- [ ] `harness_describe` with no args → still returns compact summary
- [ ] `harness_describe` with `search_term: "pipeline"` → returns pipeline-related types
- [ ] `harness_describe` with `search_term: "nonexistent"` → returns empty results with hint
- [ ] `harness_describe` with `resource_type: "pipeline"` → still returns full detail (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)