### PR TITLE
chore: migrate zod imports from v3 to v4 subpath

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 
 /**
  * Extract the account ID from a Harness PAT token.

--- a/src/prompts/access-control-audit.ts
+++ b/src/prompts/access-control-audit.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerAccessControlAuditPrompt(server: McpServer): void {

--- a/src/prompts/branch-cleanup.ts
+++ b/src/prompts/branch-cleanup.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerBranchCleanupPrompt(server: McpServer): void {

--- a/src/prompts/chaos-resilience.ts
+++ b/src/prompts/chaos-resilience.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerChaosResiliencePrompt(server: McpServer): void {

--- a/src/prompts/cloud-cost-breakdown.ts
+++ b/src/prompts/cloud-cost-breakdown.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerCloudCostBreakdownPrompt(server: McpServer): void {

--- a/src/prompts/code-review.ts
+++ b/src/prompts/code-review.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerCodeReviewPrompt(server: McpServer): void {

--- a/src/prompts/commitment-utilization.ts
+++ b/src/prompts/commitment-utilization.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerCommitmentUtilizationPrompt(server: McpServer): void {

--- a/src/prompts/cost-anomaly.ts
+++ b/src/prompts/cost-anomaly.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerCostAnomalyPrompt(server: McpServer): void {

--- a/src/prompts/create-pipeline.ts
+++ b/src/prompts/create-pipeline.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerCreatePipelinePrompt(server: McpServer): void {

--- a/src/prompts/debug-pipeline.ts
+++ b/src/prompts/debug-pipeline.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerDebugPipelinePrompt(server: McpServer): void {

--- a/src/prompts/delegate-health.ts
+++ b/src/prompts/delegate-health.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerDelegateHealthPrompt(server: McpServer): void {

--- a/src/prompts/developer-scorecard.ts
+++ b/src/prompts/developer-scorecard.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerDeveloperScorecardPrompt(server: McpServer): void {

--- a/src/prompts/dora-metrics.ts
+++ b/src/prompts/dora-metrics.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerDoraMetricsPrompt(server: McpServer): void {

--- a/src/prompts/exemption-review.ts
+++ b/src/prompts/exemption-review.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerExemptionReviewPrompt(server: McpServer): void {

--- a/src/prompts/feature-flag-rollout.ts
+++ b/src/prompts/feature-flag-rollout.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerFeatureFlagRolloutPrompt(server: McpServer): void {

--- a/src/prompts/migrate-to-template.ts
+++ b/src/prompts/migrate-to-template.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerMigrateToTemplatePrompt(server: McpServer): void {

--- a/src/prompts/onboard-service.ts
+++ b/src/prompts/onboard-service.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerOnboardServicePrompt(server: McpServer): void {

--- a/src/prompts/optimize-costs.ts
+++ b/src/prompts/optimize-costs.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerOptimizeCostsPrompt(server: McpServer): void {

--- a/src/prompts/pr-summary.ts
+++ b/src/prompts/pr-summary.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerPrSummaryPrompt(server: McpServer): void {

--- a/src/prompts/rightsizing.ts
+++ b/src/prompts/rightsizing.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerRightsizingPrompt(server: McpServer): void {

--- a/src/prompts/sbom-compliance.ts
+++ b/src/prompts/sbom-compliance.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerSbomCompliancePrompt(server: McpServer): void {

--- a/src/prompts/security-review.ts
+++ b/src/prompts/security-review.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerSecurityReviewPrompt(server: McpServer): void {

--- a/src/prompts/setup-gitops.ts
+++ b/src/prompts/setup-gitops.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerSetupGitopsPrompt(server: McpServer): void {

--- a/src/prompts/supply-chain-audit.ts
+++ b/src/prompts/supply-chain-audit.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerSupplyChainAuditPrompt(server: McpServer): void {

--- a/src/prompts/vulnerability-triage.ts
+++ b/src/prompts/vulnerability-triage.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerVulnerabilityTriagePrompt(server: McpServer): void {

--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
@@ -11,7 +11,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
     "Create a new Harness resource. Requires confirmation=true to proceed. For pipelines, templates, and triggers — read the schema resource first (e.g. schema:///pipeline) to understand the required body format.",
     {
       resource_type: z.string().describe("The type of resource to create (e.g. pipeline, service, environment, connector, trigger)"),
-      body: z.record(z.unknown()).describe("The resource definition body (varies by resource type — typically the YAML or JSON spec)"),
+      body: z.record(z.string(), z.unknown()).describe("The resource definition body (varies by resource type — typically the YAML or JSON spec)"),
       confirmation: z.boolean().describe("Must be true to confirm the create operation").default(false),
       org_id: z.string().describe("Organization identifier (overrides default)").optional(),
       project_id: z.string().describe("Project identifier (overrides default)").optional(),

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";

--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import { jsonResult } from "../utils/response-formatter.js";

--- a/src/tools/harness-diagnose.ts
+++ b/src/tools/harness-diagnose.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
@@ -25,11 +25,11 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
       app_name: z.string().describe("GitOps application name").optional(),
       experiment_id: z.string().describe("Chaos experiment identifier").optional(),
       module: z.string().describe("Harness module (CD, CI)").optional(),
-      inputs: z.record(z.unknown()).describe("Runtime inputs for pipeline execution").optional(),
+      inputs: z.record(z.string(), z.unknown()).describe("Runtime inputs for pipeline execution").optional(),
       interrupt_type: z.string().describe("Interrupt type (AbortAll, Pause, Resume, etc.)").optional(),
       enable: z.boolean().describe("Enable/disable for feature flag toggle").optional(),
       environment: z.string().describe("Target environment for feature flag operations").optional(),
-      body: z.record(z.unknown()).describe("Additional body payload for the action").optional(),
+      body: z.record(z.string(), z.unknown()).describe("Additional body payload for the action").optional(),
     },
     async (args) => {
       try {

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";

--- a/src/tools/harness-status.ts
+++ b/src/tools/harness-status.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
@@ -12,7 +12,7 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
     {
       resource_type: z.string().describe("The type of resource to update (e.g. pipeline, service, environment, connector, trigger)"),
       resource_id: z.string().describe("The identifier of the resource to update"),
-      body: z.record(z.unknown()).describe("The updated resource definition body"),
+      body: z.record(z.string(), z.unknown()).describe("The updated resource definition body"),
       confirmation: z.boolean().describe("Must be true to confirm the update operation").default(false),
       org_id: z.string().describe("Organization identifier (overrides default)").optional(),
       project_id: z.string().describe("Project identifier (overrides default)").optional(),


### PR DESCRIPTION
## Summary
- Migrate all 35 source files from `import { z } from "zod"` to `import * as z from "zod/v4"`
- Update `z.record(z.unknown())` → `z.record(z.string(), z.unknown())` in 3 tool files (v4 requires explicit key schema)
- No package.json changes — `zod@3.25.76` already ships `zod/v4` as a subpath

## Test plan
- [x] `pnpm build` — clean compile
- [x] `pnpm test` — all 81 tests pass
- [x] Smoke tested on Cursor MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)