### PR TITLE
fix(tools): standardize error handling — errorResult vs throw toMcpError

### DIFF
--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
-import { toMcpError } from "../utils/errors.js";
+import { isUserError, toMcpError } from "../utils/errors.js";
 
 export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
@@ -25,9 +25,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
         const result = await registry.dispatch(client, args.resource_type, "create", args as Record<string, unknown>);
         return jsonResult(result);
       } catch (err) {
-        if (err instanceof Error && (err.message.startsWith("Unknown resource_type") || err.message.includes("does not support"))) {
-          return errorResult(err.message);
-        }
+        if (isUserError(err)) return errorResult(err.message);
         throw toMcpError(err);
       }
     },

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
-import { toMcpError } from "../utils/errors.js";
+import { isUserError, toMcpError } from "../utils/errors.js";
 
 export function registerDeleteTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
@@ -33,9 +33,7 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
         const result = await registry.dispatch(client, args.resource_type, "delete", input);
         return jsonResult({ deleted: true, resource_type: args.resource_type, resource_id: args.resource_id, ...((typeof result === "object" && result !== null) ? result : {}) });
       } catch (err) {
-        if (err instanceof Error && (err.message.startsWith("Unknown resource_type") || err.message.includes("does not support"))) {
-          return errorResult(err.message);
-        }
+        if (isUserError(err)) return errorResult(err.message);
         throw toMcpError(err);
       }
     },

--- a/src/tools/harness-diagnose.ts
+++ b/src/tools/harness-diagnose.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
-import { toMcpError } from "../utils/errors.js";
+import { isUserError, toMcpError } from "../utils/errors.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("diagnose");
@@ -65,9 +65,7 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
 
         return jsonResult(diagnostic);
       } catch (err) {
-        if (err instanceof Error) {
-          return errorResult(err.message);
-        }
+        if (isUserError(err)) return errorResult(err.message);
         throw toMcpError(err);
       }
     },

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
-import { toMcpError } from "../utils/errors.js";
+import { isUserError, toMcpError } from "../utils/errors.js";
 
 export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
@@ -57,9 +57,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         const result = await registry.dispatchExecute(client, args.resource_type, args.action, input);
         return jsonResult(result);
       } catch (err) {
-        if (err instanceof Error && (err.message.startsWith("Unknown resource_type") || err.message.includes("no execute action"))) {
-          return errorResult(err.message);
-        }
+        if (isUserError(err)) return errorResult(err.message);
         throw toMcpError(err);
       }
     },

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
-import { toMcpError } from "../utils/errors.js";
+import { isUserError, toMcpError } from "../utils/errors.js";
 
 export function registerGetTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
@@ -37,9 +37,7 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
         const result = await registry.dispatch(client, args.resource_type, "get", input);
         return jsonResult(result);
       } catch (err) {
-        if (err instanceof Error && (err.message.startsWith("Unknown resource_type") || err.message.includes("does not support"))) {
-          return errorResult(err.message);
-        }
+        if (isUserError(err)) return errorResult(err.message);
         throw toMcpError(err);
       }
     },

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
-import { toMcpError } from "../utils/errors.js";
+import { isUserError, toMcpError } from "../utils/errors.js";
 import { compactItems } from "../utils/compact.js";
 
 export function registerListTool(server: McpServer, registry: Registry, client: HarnessClient): void {
@@ -55,12 +55,7 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
 
         return jsonResult(result);
       } catch (err) {
-        if (err instanceof Error && err.message.startsWith("Unknown resource_type")) {
-          return errorResult(err.message);
-        }
-        if (err instanceof Error && err.message.includes("does not support")) {
-          return errorResult(err.message);
-        }
+        if (isUserError(err)) return errorResult(err.message);
         throw toMcpError(err);
       }
     },

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
-import { toMcpError } from "../utils/errors.js";
+import { isUserError, toMcpError } from "../utils/errors.js";
 import { compactItems } from "../utils/compact.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -120,9 +120,7 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
           ...(Object.keys(errors).length > 0 ? { errors } : {}),
         });
       } catch (err) {
-        if (err instanceof Error) {
-          return errorResult(err.message);
-        }
+        if (isUserError(err)) return errorResult(err.message);
         throw toMcpError(err);
       }
     },

--- a/src/tools/harness-status.ts
+++ b/src/tools/harness-status.ts
@@ -5,7 +5,7 @@ import type { HarnessClient } from "../client/harness-client.js";
 import type { Config } from "../config.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { buildDeepLink } from "../utils/deep-links.js";
-import { toMcpError } from "../utils/errors.js";
+import { isUserError, toMcpError } from "../utils/errors.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("status");
@@ -194,9 +194,7 @@ export function registerStatusTool(
 
         return jsonResult(status);
       } catch (err) {
-        if (err instanceof Error) {
-          return errorResult(err.message);
-        }
+        if (isUserError(err)) return errorResult(err.message);
         throw toMcpError(err);
       }
     },

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
-import { toMcpError } from "../utils/errors.js";
+import { isUserError, toMcpError } from "../utils/errors.js";
 
 export function registerUpdateTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
@@ -40,9 +40,7 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
         const result = await registry.dispatch(client, args.resource_type, "update", input);
         return jsonResult(result);
       } catch (err) {
-        if (err instanceof Error && (err.message.startsWith("Unknown resource_type") || err.message.includes("does not support"))) {
-          return errorResult(err.message);
-        }
+        if (isUserError(err)) return errorResult(err.message);
         throw toMcpError(err);
       }
     },

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,21 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 
+/*
+ * Error handling convention for tool handlers:
+ *
+ *   return errorResult(msg)  — for user-fixable problems the LLM can act on:
+ *     bad resource_type, missing confirmation, unsupported operation, missing
+ *     required fields, validation errors. These are plain Errors thrown by the
+ *     registry/toolset layer. The LLM sees the message and can retry/adjust.
+ *
+ *   throw toMcpError(err)    — for infrastructure failures the LLM cannot fix:
+ *     HTTP 5xx, auth failures (401/403), timeouts, rate limits (429). These are
+ *     HarnessApiErrors thrown by the HTTP client. Thrown as JSON-RPC errors so
+ *     MCP clients surface them as system-level failures.
+ *
+ * Quick test: HarnessApiError → throw. Plain Error → return errorResult.
+ */
+
 /**
  * Typed error for Harness API failures.
  */
@@ -13,6 +29,14 @@ export class HarnessApiError extends Error {
     super(message);
     this.name = "HarnessApiError";
   }
+}
+
+/**
+ * Returns true for user-fixable errors (registry validation, missing fields,
+ * unknown resource types) — i.e. plain Errors that are NOT HarnessApiErrors.
+ */
+export function isUserError(err: unknown): err is Error {
+  return err instanceof Error && !(err instanceof HarnessApiError) && !(err instanceof McpError);
 }
 
 /**

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import { HarnessApiError, toMcpError } from "../../src/utils/errors.js";
+import { HarnessApiError, isUserError, toMcpError } from "../../src/utils/errors.js";
 
 describe("HarnessApiError", () => {
   it("stores statusCode, harnessCode, and correlationId", () => {
@@ -83,5 +83,25 @@ describe("toMcpError", () => {
     expect(result).toBeInstanceOf(McpError);
     expect(result.code).toBe(ErrorCode.InternalError);
     expect(result.message).toContain("raw string error");
+  });
+});
+
+describe("isUserError", () => {
+  it("returns true for plain Error", () => {
+    expect(isUserError(new Error("Unknown resource_type"))).toBe(true);
+  });
+
+  it("returns false for HarnessApiError", () => {
+    expect(isUserError(new HarnessApiError("server error", 500))).toBe(false);
+  });
+
+  it("returns false for McpError", () => {
+    expect(isUserError(new McpError(ErrorCode.InternalError, "fail"))).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isUserError("string")).toBe(false);
+    expect(isUserError(null)).toBe(false);
+    expect(isUserError(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Add `isUserError()` helper to cleanly distinguish user-fixable errors from infrastructure failures
- Fix bug in `harness_search`, `harness_diagnose`, `harness_status` where `HarnessApiError` (5xx, auth, timeouts) was silently returned as a soft `errorResult` instead of thrown as a JSON-RPC error
- Unify all 9 tool catch blocks to use `isUserError()` instead of fragile message-string matching
- Document the convention in `src/utils/errors.ts`

**Convention:**
| Error type | Source | Handler |
|---|---|---|
| Plain `Error` | Registry/toolset validation | `return errorResult(msg)` — LLM sees it, can retry |
| `HarnessApiError` | HTTP client (5xx, 401, 429) | `throw toMcpError(err)` — JSON-RPC error |

## Test plan
- [x] `pnpm build` — clean compile
- [x] `pnpm test` — all 87 tests pass (4 new for `isUserError`)
- [x] Verified `isUserError` returns false for `HarnessApiError` and `McpError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)