### PR TITLE
feat(resources): add titles, ResourceTemplate, and list/complete callbacks

### DIFF
--- a/src/resources/execution-summary.ts
+++ b/src/resources/execution-summary.ts
@@ -7,10 +7,11 @@ import { createLogger } from "../utils/logger.js";
 const log = createLogger("resource:execution-summary");
 
 export function registerExecutionSummaryResource(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
-  server.resource(
+  server.registerResource(
     "execution-summary",
     "executions:///recent",
     {
+      title: "Recent Executions",
       description: "Recent pipeline execution summaries (last 10).",
       mimeType: "application/json",
     },

--- a/src/resources/harness-schema.ts
+++ b/src/resources/harness-schema.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("resource:harness-schema");
@@ -42,10 +43,24 @@ function isValidSchemaName(name: string): name is SchemaName {
 }
 
 export function registerHarnessSchemaResource(server: McpServer): void {
-  server.resource(
+  const template = new ResourceTemplate("schema:///{schemaName}", {
+    list: async () => ({
+      resources: VALID_SCHEMAS.map((name) => ({
+        uri: `schema:///${name}`,
+        name: `${name} schema`,
+      })),
+    }),
+    complete: {
+      schemaName: (value) =>
+        VALID_SCHEMAS.filter((s) => s.startsWith(value)),
+    },
+  });
+
+  server.registerResource(
     "harness-schema",
-    "schema:///{schemaName}",
+    template,
     {
+      title: "Harness Schema",
       description: `Harness JSON Schema definitions. Valid schema names: ${VALID_SCHEMAS.join(", ")}. Use these to understand the required body format for harness_create.`,
       mimeType: "application/schema+json",
     },

--- a/src/resources/pipeline-yaml.ts
+++ b/src/resources/pipeline-yaml.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import type { Config } from "../config.js";
@@ -7,10 +8,36 @@ import { createLogger } from "../utils/logger.js";
 const log = createLogger("resource:pipeline-yaml");
 
 export function registerPipelineYamlResource(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
-  server.resource(
+  const template = new ResourceTemplate("pipeline:///{pipelineId}", {
+    list: async () => {
+      try {
+        const result = await registry.dispatch(client, "pipeline", "list", {
+          org_id: config.HARNESS_DEFAULT_ORG_ID,
+          project_id: config.HARNESS_DEFAULT_PROJECT_ID ?? "",
+          size: 20,
+          page: 0,
+        });
+        const r = result as { items?: Array<{ identifier?: string; name?: string }> };
+        return {
+          resources: (r.items ?? [])
+            .filter((p) => p.identifier)
+            .map((p) => ({
+              uri: `pipeline:///${p.identifier}`,
+              name: p.name ?? p.identifier!,
+            })),
+        };
+      } catch (err) {
+        log.warn("Failed to list pipelines for resource discovery", { error: String(err) });
+        return { resources: [] };
+      }
+    },
+  });
+
+  server.registerResource(
     "pipeline-yaml",
-    "pipeline:///{pipelineId}",
+    template,
     {
+      title: "Pipeline YAML",
       description: "Pipeline YAML definition. Provide orgId, projectId, and pipelineId in the URI path.",
       mimeType: "application/x-yaml",
     },


### PR DESCRIPTION
## Summary
- Migrate all 3 resources from deprecated `server.resource()` to `server.registerResource()`
- Add `title` to each resource so MCP clients display human-readable names instead of raw URI patterns
- Add `ResourceTemplate` with `list` callbacks to `pipeline-yaml` and `harness-schema`, enabling client-side resource browsing via `resources/list`
- Add `complete` callback to `harness-schema` for `schemaName` variable autocompletion

| Resource | Title | list | complete |
|---|---|---|---|
| pipeline-yaml | Pipeline YAML | Fetches pipelines from registry | — |
| execution-summary | Recent Executions | — (static URI) | — |
| harness-schema | Harness Schema | Enumerates pipeline/template/trigger | schemaName autocomplete |

## Test plan
- [x] `pnpm build` — clean compile
- [x] `pnpm test` — all 87 tests pass
- [x] Existing harness-schema tests still pass (no API change to exported helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)