### PR TITLE
feat: add HARNESS_READ_ONLY mode to block mutating operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ The deployment runs 2 replicas with readiness/liveness probes, resource limits, 
 | `HARNESS_RATE_LIMIT_RPS` | No | `10` | Client-side request throttle (requests per second) to Harness APIs |
 | `LOG_LEVEL` | No | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
 | `HARNESS_TOOLSETS` | No | *(all)* | Comma-separated list of enabled toolsets (see [Toolset Filtering](#toolset-filtering)) |
+| `HARNESS_READ_ONLY` | No | `false` | Block all mutating operations (create, update, delete, execute). Only list and get are allowed. Useful for shared/demo environments |
 
 ## Tools Reference
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ export const ConfigSchema = z.object({
   HARNESS_TOOLSETS: z.string().optional(),
   HARNESS_MAX_BODY_SIZE_MB: z.coerce.number().default(10),
   HARNESS_RATE_LIMIT_RPS: z.coerce.number().default(10),
+  HARNESS_READ_ONLY: z.coerce.boolean().default(false),
 });
 
 export type Config = z.infer<typeof ConfigSchema> & { HARNESS_ACCOUNT_ID: string };

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -122,6 +122,8 @@ export class Registry {
     return def?.executeActions;
   }
 
+  private static readonly READ_OPERATIONS: Set<OperationName> = new Set(["list", "get"]);
+
   /** Dispatch a CRUD operation to the Harness API. */
   async dispatch(
     client: HarnessClient,
@@ -129,6 +131,10 @@ export class Registry {
     operation: OperationName,
     input: Record<string, unknown>,
   ): Promise<unknown> {
+    if (this.config.HARNESS_READ_ONLY && !Registry.READ_OPERATIONS.has(operation)) {
+      throw new Error(`Read-only mode is enabled (HARNESS_READ_ONLY=true). "${operation}" operations are not allowed.`);
+    }
+
     const def = this.getResource(resourceType);
     const spec = def.operations[operation];
     if (!spec) {
@@ -146,6 +152,10 @@ export class Registry {
     action: string,
     input: Record<string, unknown>,
   ): Promise<unknown> {
+    if (this.config.HARNESS_READ_ONLY) {
+      throw new Error(`Read-only mode is enabled (HARNESS_READ_ONLY=true). Execute actions are not allowed.`);
+    }
+
     const def = this.getResource(resourceType);
     const actionSpec = def.executeActions?.[action];
     if (!actionSpec) {

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -229,4 +229,53 @@ describe("Registry", () => {
       ).rejects.toThrow(/body must include either pipeline/);
     });
   });
+
+  describe("read-only mode", () => {
+    let registry: Registry;
+    beforeEach(() => {
+      registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines", HARNESS_READ_ONLY: true }));
+    });
+
+    it("allows list operations", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } });
+      const client = makeClient(mockRequest);
+      await registry.dispatch(client, "pipeline", "list", {});
+      expect(mockRequest).toHaveBeenCalledOnce();
+    });
+
+    it("allows get operations", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ data: { identifier: "p1" } });
+      const client = makeClient(mockRequest);
+      await registry.dispatch(client, "pipeline", "get", { pipeline_id: "p1" });
+      expect(mockRequest).toHaveBeenCalledOnce();
+    });
+
+    it("blocks create operations", async () => {
+      const client = makeClient();
+      await expect(
+        registry.dispatch(client, "pipeline", "create", { body: {} }),
+      ).rejects.toThrow(/Read-only mode/);
+    });
+
+    it("blocks update operations", async () => {
+      const client = makeClient();
+      await expect(
+        registry.dispatch(client, "pipeline", "update", { pipeline_id: "p1", body: {} }),
+      ).rejects.toThrow(/Read-only mode/);
+    });
+
+    it("blocks delete operations", async () => {
+      const client = makeClient();
+      await expect(
+        registry.dispatch(client, "pipeline", "delete", { pipeline_id: "p1" }),
+      ).rejects.toThrow(/Read-only mode/);
+    });
+
+    it("blocks execute actions", async () => {
+      const client = makeClient();
+      await expect(
+        registry.dispatchExecute(client, "pipeline", "run", { pipeline_id: "p1" }),
+      ).rejects.toThrow(/Read-only mode/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add `HARNESS_READ_ONLY` config option (default `false`)
- Gate at `Registry.dispatch()` and `Registry.dispatchExecute()` — the single chokepoint for all API calls
- When enabled: `list` and `get` pass through; `create`, `update`, `delete`, and all execute actions throw a clear error
- Document in README configuration table

## Files changed
- `src/config.ts` — add `HARNESS_READ_ONLY` field (boolean, default false)
- `src/registry/index.ts` — 2 guard clauses (~6 lines)
- `tests/registry/registry.test.ts` — 6 new tests covering all blocked/allowed operations
- `README.md` — config table entry

## Test plan
- [x] `pnpm build` — clean compile
- [x] `pnpm test` — all 93 tests pass (6 new read-only tests)
- [x] Verified list/get still work in read-only mode
- [x] Verified create/update/delete/execute are blocked with descriptive error

🤖 Generated with [Claude Code](https://claude.com/claude-code)