### PR TITLE
test: add HarnessClient, compactItems, and RateLimiter tests (+35)

### DIFF
--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HarnessClient } from "../../src/client/harness-client.js";
+import { HarnessApiError } from "../../src/utils/errors.js";
+import type { Config } from "../../src/config.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test-account.token.secret",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_DEFAULT_ORG_ID: "default",
+    HARNESS_DEFAULT_PROJECT_ID: "test-project",
+    HARNESS_API_TIMEOUT_MS: 5000,
+    HARNESS_MAX_RETRIES: 2,
+    LOG_LEVEL: "error",
+    HARNESS_RATE_LIMIT_RPS: 1000, // high limit so rate limiter doesn't interfere
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_READ_ONLY: false,
+    ...overrides,
+  };
+}
+
+describe("HarnessClient", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor and account getter", () => {
+    it("exposes account ID", () => {
+      const client = new HarnessClient(makeConfig());
+      expect(client.account).toBe("test-account");
+    });
+  });
+
+  describe("request — URL building", () => {
+    it("builds URL with accountIdentifier and custom params", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ data: "ok" }), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ method: "GET", path: "/ng/api/projects", params: { orgIdentifier: "myorg" } });
+
+      const url = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(url.origin).toBe("https://app.harness.io");
+      expect(url.pathname).toBe("/ng/api/projects");
+      expect(url.searchParams.get("accountIdentifier")).toBe("test-account");
+      expect(url.searchParams.get("orgIdentifier")).toBe("myorg");
+    });
+
+    it("adds accountID param for log-service paths", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ path: "/gateway/log-service/blob/download" });
+
+      const url = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(url.searchParams.get("accountID")).toBe("test-account");
+      expect(url.searchParams.get("accountIdentifier")).toBe("test-account");
+    });
+
+    it("strips trailing slash from base URL", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_BASE_URL: "https://app.harness.io/" }));
+
+      await client.request({ path: "/ng/api/test" });
+
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain("https://app.harness.io/ng/api/test?");
+    });
+
+    it("omits undefined and empty params", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ path: "/test", params: { a: "1", b: undefined, c: "" } });
+
+      const url = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(url.searchParams.get("a")).toBe("1");
+      expect(url.searchParams.has("b")).toBe(false);
+      expect(url.searchParams.has("c")).toBe(false);
+    });
+  });
+
+  describe("request — headers", () => {
+    it("sets x-api-key and Harness-Account headers", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ path: "/test" });
+
+      const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers["x-api-key"]).toBe("pat.test-account.token.secret");
+      expect(headers["Harness-Account"]).toBe("test-account");
+    });
+
+    it("sets Content-Type to application/json for object body", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ method: "POST", path: "/test", body: { key: "value" } });
+
+      const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/json");
+    });
+
+    it("sets Content-Type to application/yaml for string body", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ method: "PUT", path: "/test", body: "pipeline:\n  name: test" });
+
+      const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/yaml");
+    });
+
+    it("allows Content-Type override via options.headers", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ method: "POST", path: "/test", body: "data", headers: { "Content-Type": "text/plain" } });
+
+      const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("text/plain");
+    });
+  });
+
+  describe("request — success", () => {
+    it("returns parsed JSON on 200", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ data: { id: "p1" } }), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      const result = await client.request<{ data: { id: string } }>({ path: "/test" });
+      expect(result.data.id).toBe("p1");
+    });
+  });
+
+  describe("request — error handling", () => {
+    it("throws HarnessApiError with parsed message on 400", async () => {
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ message: "Invalid input", code: "INVALID", correlationId: "corr-1" }),
+        { status: 400 },
+      ));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      try {
+        await client.request({ path: "/test" });
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HarnessApiError);
+        const e = err as HarnessApiError;
+        expect(e.message).toBe("Invalid input");
+        expect(e.statusCode).toBe(400);
+        expect(e.harnessCode).toBe("INVALID");
+        expect(e.correlationId).toBe("corr-1");
+      }
+    });
+
+    it("throws HarnessApiError with raw body on non-JSON error", async () => {
+      fetchSpy.mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      await expect(client.request({ path: "/test" })).rejects.toThrow(/HTTP 502: Bad Gateway/);
+    });
+
+    it("does not retry on 400", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ message: "bad" }), { status: 400 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 2 }));
+
+      await expect(client.request({ path: "/test" })).rejects.toThrow(HarnessApiError);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry on 401", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ message: "unauthorized" }), { status: 401 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 2 }));
+
+      await expect(client.request({ path: "/test" })).rejects.toThrow(HarnessApiError);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("request — retry logic", () => {
+    it("retries on 500 and succeeds", async () => {
+      fetchSpy
+        .mockResolvedValueOnce(new Response(JSON.stringify({ message: "fail" }), { status: 500 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ data: "ok" }), { status: 200 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 2 }));
+
+      const result = await client.request<{ data: string }>({ path: "/test" });
+      expect(result.data).toBe("ok");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries on 429 and succeeds", async () => {
+      fetchSpy
+        .mockResolvedValueOnce(new Response(JSON.stringify({ message: "rate limited" }), { status: 429 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ data: "ok" }), { status: 200 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 2 }));
+
+      const result = await client.request<{ data: string }>({ path: "/test" });
+      expect(result.data).toBe("ok");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws after exhausting retries on 503", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ message: "unavailable" }), { status: 503 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 1 }));
+
+      await expect(client.request({ path: "/test" })).rejects.toThrow(HarnessApiError);
+      // initial + 1 retry = 2 calls
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("request — timeout", () => {
+    it("throws HarnessApiError with 408 on timeout", async () => {
+      fetchSpy.mockImplementation(() => new Promise((_, reject) => {
+        setTimeout(() => {
+          const err = new Error("The operation was aborted");
+          err.name = "AbortError";
+          reject(err);
+        }, 10);
+      }));
+      const client = new HarnessClient(makeConfig({ HARNESS_API_TIMEOUT_MS: 1, HARNESS_MAX_RETRIES: 0 }));
+
+      try {
+        await client.request({ path: "/test" });
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HarnessApiError);
+        expect((err as HarnessApiError).statusCode).toBe(408);
+        expect((err as HarnessApiError).message).toContain("timed out");
+      }
+    });
+  });
+
+  describe("request — network errors", () => {
+    it("wraps fetch errors as HarnessApiError with 502", async () => {
+      fetchSpy.mockRejectedValue(new Error("DNS resolution failed"));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      try {
+        await client.request({ path: "/test" });
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HarnessApiError);
+        expect((err as HarnessApiError).statusCode).toBe(502);
+        expect((err as HarnessApiError).message).toContain("DNS resolution failed");
+      }
+    });
+  });
+
+  describe("request — body serialization", () => {
+    it("sends JSON-stringified body for objects", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ method: "POST", path: "/test", body: { key: "val" } });
+
+      const body = fetchSpy.mock.calls[0][1]?.body as string;
+      expect(JSON.parse(body)).toEqual({ key: "val" });
+    });
+
+    it("sends raw string body as-is", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ method: "PUT", path: "/test", body: "raw yaml content" });
+
+      const body = fetchSpy.mock.calls[0][1]?.body as string;
+      expect(body).toBe("raw yaml content");
+    });
+  });
+});

--- a/tests/utils/compact.test.ts
+++ b/tests/utils/compact.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { compactItems } from "../../src/utils/compact.js";
+
+describe("compactItems", () => {
+  it("keeps identity fields", () => {
+    const items = [{ identifier: "p1", name: "Pipeline 1", description: "A pipeline", slug: "p1" }];
+    const result = compactItems(items) as Record<string, unknown>[];
+    expect(result[0]).toEqual({ identifier: "p1", name: "Pipeline 1", description: "A pipeline", slug: "p1" });
+  });
+
+  it("keeps status fields", () => {
+    const items = [{ status: "Running", enabled: true, health: "good" }];
+    const result = compactItems(items) as Record<string, unknown>[];
+    expect(result[0]).toEqual({ status: "Running", enabled: true, health: "good" });
+  });
+
+  it("keeps type fields", () => {
+    const items = [{ type: "DockerRegistry", kind: "Connector", category: "cloud", module: "CD" }];
+    const result = compactItems(items) as Record<string, unknown>[];
+    expect(result[0]).toEqual({ type: "DockerRegistry", kind: "Connector", category: "cloud", module: "CD" });
+  });
+
+  it("keeps ownership fields", () => {
+    const items = [{ tags: ["prod"], labels: { env: "prod" }, owner: "alice", author: "bob" }];
+    const result = compactItems(items) as Record<string, unknown>[];
+    expect(result[0]).toEqual({ tags: ["prod"], labels: { env: "prod" }, owner: "alice", author: "bob" });
+  });
+
+  it("keeps timestamp fields matching pattern", () => {
+    const items = [{ createdAt: 1000, lastModifiedTs: 2000, startTime: 3000, updatedDate: "2025-01-01" }];
+    const result = compactItems(items) as Record<string, unknown>[];
+    expect(result[0]).toEqual({ createdAt: 1000, lastModifiedTs: 2000, startTime: 3000, updatedDate: "2025-01-01" });
+  });
+
+  it("keeps identifier-like fields matching pattern", () => {
+    const items = [{ pipelineIdentifier: "p1", projectId: "proj", env_id: "env1" }];
+    const result = compactItems(items) as Record<string, unknown>[];
+    expect(result[0]).toEqual({ pipelineIdentifier: "p1", projectId: "proj", env_id: "env1" });
+  });
+
+  it("strips verbose metadata fields", () => {
+    const items = [{
+      identifier: "p1",
+      name: "Pipeline",
+      yaml: "pipeline:\n  ...",
+      executionSummaryInfo: { deployments: [] },
+      governanceMetadata: { rules: [] },
+      gitDetails: { repoName: "repo" },
+      storeType: "INLINE",
+      connectorRef: "ref",
+      entityValidityDetails: {},
+    }];
+    const result = compactItems(items) as Record<string, unknown>[];
+    expect(result[0]).toEqual({ identifier: "p1", name: "Pipeline" });
+  });
+
+  it("merges openInHarness into name as markdown link", () => {
+    const items = [{ name: "My Pipeline", openInHarness: "https://app.harness.io/ng/pipelines/p1" }];
+    const result = compactItems(items) as Record<string, unknown>[];
+    expect(result[0].name).toBe("[My Pipeline](https://app.harness.io/ng/pipelines/p1)");
+    expect(result[0].openInHarness).toBeUndefined();
+  });
+
+  it("keeps openInHarness if name is absent", () => {
+    const items = [{ identifier: "p1", openInHarness: "https://app.harness.io/ng/pipelines/p1" }];
+    const result = compactItems(items) as Record<string, unknown>[];
+    expect(result[0].openInHarness).toBe("https://app.harness.io/ng/pipelines/p1");
+  });
+
+  it("passes through non-object items unchanged", () => {
+    const items = ["string", 42, null];
+    expect(compactItems(items)).toEqual(["string", 42, null]);
+  });
+
+  it("handles empty array", () => {
+    expect(compactItems([])).toEqual([]);
+  });
+});

--- a/tests/utils/rate-limiter.test.ts
+++ b/tests/utils/rate-limiter.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { RateLimiter } from "../../src/utils/rate-limiter.js";
+
+describe("RateLimiter", () => {
+  it("allows burst up to max tokens", async () => {
+    const limiter = new RateLimiter(5);
+    const start = Date.now();
+
+    for (let i = 0; i < 5; i++) {
+      await limiter.acquire();
+    }
+
+    // All 5 should complete nearly instantly (< 50ms)
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it("throttles after burst is exhausted", async () => {
+    const limiter = new RateLimiter(2);
+
+    // Exhaust the burst
+    await limiter.acquire();
+    await limiter.acquire();
+
+    const start = Date.now();
+    await limiter.acquire(); // should wait for refill
+    const elapsed = Date.now() - start;
+
+    // At 2 tokens/sec, refill 1 token takes ~500ms. Allow some tolerance.
+    expect(elapsed).toBeGreaterThanOrEqual(50);
+  });
+
+  it("refills tokens over time", async () => {
+    const limiter = new RateLimiter(3);
+
+    // Exhaust burst
+    await limiter.acquire();
+    await limiter.acquire();
+    await limiter.acquire();
+
+    // Wait for partial refill
+    await new Promise((r) => setTimeout(r, 400));
+
+    // Should be able to acquire at least one token now
+    const start = Date.now();
+    await limiter.acquire();
+    expect(Date.now() - start).toBeLessThan(100);
+  });
+});


### PR DESCRIPTION
## Summary
Fill the three legitimate test coverage gaps identified in the code review:

| Test file | Tests | What's covered |
|---|---|---|
| `tests/client/harness-client.test.ts` | 21 | URL building, auth header injection, Content-Type handling, error mapping (400/401/502), retry on 429/500/503, retry exhaustion, timeout (408), network errors, body serialization |
| `tests/utils/compact.test.ts` | 11 | Identity/status/type/ownership field whitelists, timestamp & identifier patterns, verbose metadata stripping, openInHarness→markdown merge, edge cases |
| `tests/utils/rate-limiter.test.ts` | 3 | Burst allowance, throttling after exhaustion, token refill over time |

**Test count: 93 → 128 (+35 tests)**

## Test plan
- [x] `pnpm build` — clean compile
- [x] `pnpm test` — all 128 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)