### PR TITLE
fix: add global error handlers for process protection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,15 @@ async function startHttp(config: Config, port: number): Promise<void> {
 }
 
 async function main(): Promise<void> {
+  // Global error handlers — must be installed before anything else.
+  process.on("unhandledRejection", (reason) => {
+    log.error("Unhandled promise rejection", { error: String(reason), stack: (reason as Error)?.stack });
+  });
+  process.on("uncaughtException", (err) => {
+    log.error("Uncaught exception — exiting", { error: err.message, stack: err.stack });
+    process.exit(1);
+  });
+
   const config = loadConfig();
   setLogLevel(config.LOG_LEVEL);
 


### PR DESCRIPTION
## Summary
- Adds `process.on("unhandledRejection")` handler that logs the error and lets the event loop continue
- Adds `process.on("uncaughtException")` handler that logs with full stack trace and exits with code 1
- Installed at the top of `main()` before any other initialization

## Why
Node.js 20+ crashes on unhandled promise rejections by default. A single malformed API response or stray async error in a tool handler could bring down the entire MCP server. These handlers ensure errors are logged with full context instead of silent crashes.

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — 128 tests pass
- [x] No behavior change for working code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)