### PR TITLE
feat: add logging capability and progress notifications

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,12 +22,15 @@ function createHarnessServer(config: Config): McpServer {
   const client = new HarnessClient(config);
   const registry = new Registry(config);
 
-  const server = new McpServer({
-    name: "harness-mcp-server",
-    version: "1.0.0",
-    icons: [{ src: "https://app.harness.io/favicon.ico" }],
-    websiteUrl: "https://harness.io",
-  });
+  const server = new McpServer(
+    {
+      name: "harness-mcp-server",
+      version: "1.0.0",
+      icons: [{ src: "https://app.harness.io/favicon.ico" }],
+      websiteUrl: "https://harness.io",
+    },
+    { capabilities: { logging: {} } },
+  );
 
   registerAllTools(server, registry, client, config);
   registerAllResources(server, registry, client, config);

--- a/src/tools/harness-diagnose.ts
+++ b/src/tools/harness-diagnose.ts
@@ -5,6 +5,7 @@ import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, toMcpError } from "../utils/errors.js";
 import { createLogger } from "../utils/logger.js";
+import { sendProgress } from "../utils/progress.js";
 
 const log = createLogger("diagnose");
 
@@ -19,12 +20,15 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
       include_yaml: z.boolean().describe("Include the full pipeline YAML definition").default(true).optional(),
       include_logs: z.boolean().describe("Include execution step logs").default(true).optional(),
     },
-    async (args) => {
+    async (args, extra) => {
       try {
         const input: Record<string, unknown> = { ...args };
         const diagnostic: Record<string, unknown> = {};
+        const totalSteps = 1 + (args.include_yaml !== false ? 1 : 0) + (args.include_logs !== false ? 1 : 0);
+        let step = 0;
 
         // 1. Get execution details
+        await sendProgress(extra, step, totalSteps, "Fetching execution details...");
         log.info("Fetching execution details", { executionId: args.execution_id });
         try {
           const execution = await registry.dispatch(client, "execution", "get", input);
@@ -35,8 +39,11 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
           const pipelineExec = exec?.pipelineExecutionSummary as Record<string, unknown> | undefined;
           const pipelineId = pipelineExec?.pipelineIdentifier as string | undefined;
 
+          step++;
+
           // 2. Get pipeline YAML if requested and pipeline ID available
           if (args.include_yaml !== false && pipelineId) {
+            await sendProgress(extra, step, totalSteps, "Fetching pipeline YAML...");
             try {
               const pipeline = await registry.dispatch(client, "pipeline", "get", {
                 ...input,
@@ -54,6 +61,8 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
 
         // 3. Get execution logs if requested
         if (args.include_logs !== false) {
+          step++;
+          await sendProgress(extra, step, totalSteps, "Fetching execution logs...");
           try {
             const logs = await registry.dispatch(client, "execution_log", "get", input);
             diagnostic.logs = logs;
@@ -63,6 +72,7 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
           }
         }
 
+        await sendProgress(extra, totalSteps, totalSteps, "Diagnosis complete");
         return jsonResult(diagnostic);
       } catch (err) {
         if (isUserError(err)) return errorResult(err.message);

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -6,6 +6,7 @@ import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, toMcpError } from "../utils/errors.js";
 import { compactItems } from "../utils/compact.js";
 import { createLogger } from "../utils/logger.js";
+import { sendProgress, sendLog } from "../utils/progress.js";
 
 const log = createLogger("search");
 
@@ -42,7 +43,7 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
       max_per_type: z.number().describe("Max results per resource type").default(5).optional(),
       compact: z.boolean().describe("Strip verbose metadata from results (default true)").default(true).optional(),
     },
-    async (args) => {
+    async (args, extra) => {
       try {
         // Determine which resource types to search
         let targetTypes = args.resource_types ?? [];
@@ -57,9 +58,11 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
         // Run searches with concurrency limit to avoid overwhelming the API
         const MAX_CONCURRENCY = 5;
         const settled: { rt: string; result: unknown; error: string | null }[] = [];
+        let searched = 0;
 
         for (let i = 0; i < targetTypes.length; i += MAX_CONCURRENCY) {
           const batch = targetTypes.slice(i, i + MAX_CONCURRENCY);
+          await sendProgress(extra, searched, targetTypes.length, `Searching batch ${Math.floor(i / MAX_CONCURRENCY) + 1}...`);
           const batchResults = await Promise.all(
             batch.map(async (rt) => {
               try {
@@ -81,7 +84,9 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
             }),
           );
           settled.push(...batchResults);
+          searched += batch.length;
         }
+        await sendProgress(extra, targetTypes.length, targetTypes.length, "Processing results...");
         let totalMatches = 0;
 
         for (const { rt, result, error } of settled) {

--- a/src/tools/harness-status.ts
+++ b/src/tools/harness-status.ts
@@ -7,6 +7,7 @@ import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { buildDeepLink } from "../utils/deep-links.js";
 import { isUserError, toMcpError } from "../utils/errors.js";
 import { createLogger } from "../utils/logger.js";
+import { sendProgress } from "../utils/progress.js";
 
 const log = createLogger("status");
 
@@ -75,7 +76,7 @@ export function registerStatusTool(
       project_id: z.string().describe("Project identifier (overrides default)").optional(),
       limit: z.number().describe("Max items per section (default 5, max 20)").default(5).optional(),
     },
-    async (args) => {
+    async (args, extra) => {
       try {
         const orgId = args.org_id ?? config.HARNESS_DEFAULT_ORG_ID;
         const projectId = args.project_id ?? config.HARNESS_DEFAULT_PROJECT_ID ?? "";
@@ -89,6 +90,7 @@ export function registerStatusTool(
         };
 
         log.info("Fetching project status", { orgId, projectId, limit });
+        await sendProgress(extra, 0, 2, "Fetching failed, running, and recent executions...");
 
         // 3 parallel dispatches: failed, running, recent activity
         const [failedResult, runningResult, recentResult] = await Promise.allSettled([
@@ -126,6 +128,8 @@ export function registerStatusTool(
         if (recentResult.status === "rejected") {
           log.warn("Failed to fetch recent executions", { error: String(recentResult.reason) });
         }
+
+        await sendProgress(extra, 1, 2, "Building status summary...");
 
         const failedItems = (failed?.items ?? []).map((e) =>
           summarizeExecution(e, config.HARNESS_BASE_URL, config.HARNESS_ACCOUNT_ID, orgId, projectId),
@@ -169,6 +173,8 @@ export function registerStatusTool(
         if (failedResult.status === "rejected") errors.failed = String(failedResult.reason);
         if (runningResult.status === "rejected") errors.running = String(runningResult.reason);
         if (recentResult.status === "rejected") errors.recent = String(recentResult.reason);
+
+        await sendProgress(extra, 2, 2, "Status complete");
 
         const status: Record<string, unknown> = {
           project: {

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,0 +1,53 @@
+/**
+ * Helpers for sending MCP progress and logging notifications from tool handlers.
+ *
+ * Usage: call `sendProgress(extra, ...)` or `sendLog(extra, ...)` from any tool
+ * handler that accepts the `extra` (second) parameter.
+ */
+
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type { ServerRequest, ServerNotification } from "@modelcontextprotocol/sdk/types.js";
+
+type Extra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+/**
+ * Send a progress notification tied to the current request.
+ * No-op if the client didn't provide a progressToken.
+ */
+export async function sendProgress(
+  extra: Extra,
+  progress: number,
+  total: number | undefined,
+  message?: string,
+): Promise<void> {
+  const token = extra._meta?.progressToken;
+  if (token === undefined) return;
+  try {
+    await extra.sendNotification({
+      method: "notifications/progress",
+      params: { progressToken: token, progress, total, message },
+    });
+  } catch {
+    // Non-critical — client may not support progress
+  }
+}
+
+/**
+ * Send a logging notification to the client.
+ * No-op silently if the send fails.
+ */
+export async function sendLog(
+  extra: Extra,
+  level: "debug" | "info" | "warning" | "error",
+  logger: string,
+  data: string,
+): Promise<void> {
+  try {
+    await extra.sendNotification({
+      method: "notifications/message",
+      params: { level, logger, data },
+    });
+  } catch {
+    // Non-critical — client may not support logging
+  }
+}


### PR DESCRIPTION
## Summary
- Declares `logging: {}` capability in McpServer options so clients know the server can send log notifications
- Adds `sendProgress()` and `sendLog()` helpers in `src/utils/progress.ts` — safe no-ops when client doesn't support them
- Sends MCP progress notifications (`notifications/progress`) in the 3 long-running tools:
  - **harness_search**: progress per batch (e.g., "Searching batch 2 of 8...")
  - **harness_diagnose**: progress per step (execution details → pipeline YAML → logs)
  - **harness_status**: progress across fetch → summarize phases
- Tool handler signatures updated from `(args)` to `(args, extra)` only for these 3 tools

## What this does NOT change
- The other 7 tool handlers keep `(args)` — they're fast single-request tools that don't need progress
- No config changes, no new dependencies
- Progress is a no-op when the client doesn't provide a `progressToken` in the request `_meta`

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — 128 tests pass
- [x] Progress helpers are resilient (catch + ignore errors from clients that don't support notifications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)