### PR TITLE
feat: add fme_feature_flag resource type (parity with harness/mcp-server#36)

### DIFF
--- a/src/registry/toolsets/feature-flags.ts
+++ b/src/registry/toolsets/feature-flags.ts
@@ -58,6 +58,24 @@ export const featureFlagsToolset: ToolsetDefinition = {
       },
     },
     {
+      resourceType: "fme_feature_flag",
+      displayName: "FME Feature Flag",
+      description:
+        "Feature flag basic metadata (name, description, traffic type, tags, rollout status) via the Split.io API. Does not require an environment — use feature_flag get for environment-specific definitions.",
+      toolset: "feature-flags",
+      scope: "account",
+      identifierFields: ["workspace_id", "feature_flag_name"],
+      operations: {
+        get: {
+          method: "GET",
+          path: "/internal/api/v2/splits/ws/{wsId}/{featureFlagName}",
+          pathParams: { workspace_id: "wsId", feature_flag_name: "featureFlagName" },
+          responseExtractor: passthrough,
+          description: "Get a specific feature flag's metadata without requiring an environment",
+        },
+      },
+    },
+    {
       resourceType: "feature_flag",
       displayName: "Feature Flag",
       description:


### PR DESCRIPTION
## Summary
- Adds `fme_feature_flag` resource type to the `feature-flags` toolset
- Exposes `GET /internal/api/v2/splits/ws/{wsId}/{featureFlagName}` (Split.io API)
- Returns basic flag metadata (name, description, traffic type, tags, rollout status) **without requiring an environment**
- Complements the existing `feature_flag` resource which returns environment-specific definitions

## Usage
```
harness_get(resource_type="fme_feature_flag", workspace_id="<ws_id>", feature_flag_name="<name>")
```

## Parity
Mirrors [harness/mcp-server#36](https://github.com/harness/mcp-server/pull/36) (`get_fme_feature_flag` tool in the Go server).

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — 128 tests pass
- [x] Verified resource registers with correct scope (`account`), identifiers (`workspace_id`, `feature_flag_name`), and path params

🤖 Generated with [Claude Code](https://claude.com/claude-code)