### PR TITLE
feat: add pagination to fme_workspace list (parity with harness/mcp-server#35)

### DIFF
--- a/src/registry/toolsets/feature-flags.ts
+++ b/src/registry/toolsets/feature-flags.ts
@@ -28,16 +28,21 @@ export const featureFlagsToolset: ToolsetDefinition = {
     {
       resourceType: "fme_workspace",
       displayName: "FME Workspace",
-      description: "Feature Management workspace. Supports list.",
+      description: "Feature Management workspace. Supports list with pagination (offset/size, default 20, max 1000).",
       toolset: "feature-flags",
       scope: "project",
       identifierFields: ["workspace_id"],
+      listFilterFields: ["offset"],
       operations: {
         list: {
           method: "GET",
           path: "/cf/admin/workspaces",
+          queryParams: {
+            offset: "offset",
+            size: "limit",
+          },
           responseExtractor: passthrough,
-          description: "List FME workspaces",
+          description: "List FME workspaces with pagination (offset and size params, max 1000)",
         },
       },
     },


### PR DESCRIPTION
## Summary
- Adds `offset` and `limit` query params to the `fme_workspace` list operation
- Maps `size` → `limit` and `offset` → `offset` for the Split.io API (`GET /internal/api/v2/workspaces`)
- Users can paginate via `harness_list(resource_type="fme_workspace", offset=20, size=20)`

## Parity
Mirrors [harness/mcp-server#35](https://github.com/harness/mcp-server/pull/35) (pagination for `list_fme_workspaces` in the Go server).

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — 128 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)