### PR TITLE
feat: add fme_feature_flag list with pagination (parity with harness/mcp-server#34)

### DIFF
--- a/src/registry/toolsets/feature-flags.ts
+++ b/src/registry/toolsets/feature-flags.ts
@@ -66,11 +66,23 @@ export const featureFlagsToolset: ToolsetDefinition = {
       resourceType: "fme_feature_flag",
       displayName: "FME Feature Flag",
       description:
-        "Feature flag basic metadata (name, description, traffic type, tags, rollout status) via the Split.io API. Does not require an environment — use feature_flag get for environment-specific definitions.",
+        "Feature flag via the Split.io API. List flags by workspace with pagination (offset/size, default 20, max 50), or get a single flag's metadata. Does not require an environment.",
       toolset: "feature-flags",
       scope: "account",
       identifierFields: ["workspace_id", "feature_flag_name"],
+      listFilterFields: ["offset"],
       operations: {
+        list: {
+          method: "GET",
+          path: "/internal/api/v2/splits/ws/{wsId}",
+          pathParams: { workspace_id: "wsId" },
+          queryParams: {
+            offset: "offset",
+            size: "limit",
+          },
+          responseExtractor: passthrough,
+          description: "List feature flags for a workspace with pagination (offset and size params, max 50)",
+        },
         get: {
           method: "GET",
           path: "/internal/api/v2/splits/ws/{wsId}/{featureFlagName}",


### PR DESCRIPTION
## Summary
- Adds `fme_feature_flag` resource type with a `list` operation via the Split.io API (`GET /internal/api/v2/splits/ws/{wsId}`)
- Supports `offset` and `limit` query params for pagination (default 20, max 50)
- Requires `workspace_id` as a path param — separate from the existing `feature_flag` resource which uses the CF admin API

## Usage
```
harness_list(resource_type="fme_feature_flag", workspace_id="<ws_id>", offset=0, size=20)
```

## Parity
Mirrors [harness/mcp-server#34](https://github.com/harness/mcp-server/pull/34) (pagination for `list_fme_feature_flags` in the Go server).

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — 128 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)