### PR TITLE
feat: MCP elicitation for write tool confirmation

### DIFF
--- a/src/prompts/feature-flag-rollout.ts
+++ b/src/prompts/feature-flag-rollout.ts
@@ -32,7 +32,7 @@ Steps:
 6. **Safety gates**: Identify metrics or health checks between each phase
 7. **Rollback plan**: Define conditions that trigger automatic rollback
 
-Present the rollout plan for review. Use harness_execute with resource_type="feature_flag", action="toggle" to execute each phase only after confirmation.`,
+Present the rollout plan for review. Use harness_execute with resource_type="feature_flag", action="toggle" to execute each phase after user approval.`,
           },
         }],
       };

--- a/src/prompts/pending-approvals.ts
+++ b/src/prompts/pending-approvals.ts
@@ -33,7 +33,7 @@ For each pending approval, show:
 - A deep link to the execution in Harness
 
 **Step 4: Offer to take action**
-Ask me if I want to approve or reject any of the pending approvals. If I choose to act, use harness_execute with resource_type="approval_instance", action="approve" (or "reject"), approval_id=<id>, and confirmation=true.
+Ask me if I want to approve or reject any of the pending approvals. If I choose to act, use harness_execute with resource_type="approval_instance", action="approve" (or "reject"), approval_id=<id>.
 
 If no executions are waiting for approval, let me know the project is clear.`,
         },

--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -4,22 +4,27 @@ import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, toMcpError } from "../utils/errors.js";
+import { confirmViaElicitation } from "../utils/elicitation.js";
 
 export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
     "harness_create",
-    "Create a new Harness resource. Requires confirmation=true to proceed. For pipelines, templates, and triggers — read the schema resource first (e.g. schema:///pipeline) to understand the required body format.",
+    "Create a new Harness resource. For pipelines, templates, and triggers — read the schema resource first (e.g. schema:///pipeline) to understand the required body format.",
     {
       resource_type: z.string().describe("The type of resource to create (e.g. pipeline, service, environment, connector, trigger)"),
       body: z.record(z.string(), z.unknown()).describe("The resource definition body (varies by resource type — typically the YAML or JSON spec)"),
-      confirmation: z.boolean().describe("Must be true to confirm the create operation").default(false),
       org_id: z.string().describe("Organization identifier (overrides default)").optional(),
       project_id: z.string().describe("Project identifier (overrides default)").optional(),
     },
     async (args) => {
       try {
-        if (!args.confirmation) {
-          return errorResult("Create operations require confirmation=true. Set confirmation to true to proceed.");
+        const elicit = await confirmViaElicitation({
+          server,
+          toolName: "harness_create",
+          message: `Create ${args.resource_type}?\n\n${JSON.stringify(args.body, null, 2)}`,
+        });
+        if (!elicit.proceed) {
+          return errorResult(`Operation ${elicit.reason} by user.`);
         }
 
         const result = await registry.dispatch(client, args.resource_type, "create", args as Record<string, unknown>);

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -4,15 +4,15 @@ import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, toMcpError } from "../utils/errors.js";
+import { confirmViaElicitation } from "../utils/elicitation.js";
 
 export function registerDeleteTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
     "harness_delete",
-    "Delete a Harness resource. Requires confirmation=true to proceed. This is destructive and cannot be undone.",
+    "Delete a Harness resource. This is destructive and cannot be undone.",
     {
       resource_type: z.string().describe("The type of resource to delete (e.g. pipeline, trigger, connector)"),
       resource_id: z.string().describe("The identifier of the resource to delete"),
-      confirmation: z.boolean().describe("Must be true to confirm the delete operation — this is destructive").default(false),
       org_id: z.string().describe("Organization identifier (overrides default)").optional(),
       project_id: z.string().describe("Project identifier (overrides default)").optional(),
       pipeline_id: z.string().describe("Pipeline ID (for trigger deletes)").optional(),
@@ -20,8 +20,13 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
     },
     async (args) => {
       try {
-        if (!args.confirmation) {
-          return errorResult("Delete operations require confirmation=true. This is destructive and cannot be undone.");
+        const elicit = await confirmViaElicitation({
+          server,
+          toolName: "harness_delete",
+          message: `Delete ${args.resource_type} "${args.resource_id}"?\n\nThis is destructive and cannot be undone.`,
+        });
+        if (!elicit.proceed) {
+          return errorResult(`Operation ${elicit.reason} by user.`);
         }
 
         const def = registry.getResource(args.resource_type);

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -4,6 +4,7 @@ import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, toMcpError } from "../utils/errors.js";
+import { confirmViaElicitation } from "../utils/elicitation.js";
 
 export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
@@ -13,7 +14,6 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
       resource_type: z.string().describe("The resource type (e.g. pipeline, execution, feature_flag, connector, gitops_application, chaos_experiment)"),
       action: z.string().describe("The action to execute (e.g. run, retry, interrupt, toggle, test_connection, sync)"),
       resource_id: z.string().describe("The primary identifier of the resource").optional(),
-      confirmation: z.boolean().describe("Must be true to confirm execution").default(false),
       org_id: z.string().describe("Organization identifier (overrides default)").optional(),
       project_id: z.string().describe("Project identifier (overrides default)").optional(),
       // Dynamic fields for various actions
@@ -36,18 +36,13 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
     },
     async (args) => {
       try {
-        if (!args.confirmation) {
-          // Show available actions for the resource type
-          const actions = registry.getExecuteActions(args.resource_type);
-          if (!actions) {
-            return errorResult(`Resource "${args.resource_type}" has no execute actions.`);
-          }
-          const actionList = Object.entries(actions)
-            .map(([name, spec]) => `  - ${name}: ${spec.actionDescription}`)
-            .join("\n");
-          return errorResult(
-            `Execute operations require confirmation=true.\n\nAvailable actions for "${args.resource_type}":\n${actionList}`,
-          );
+        const elicit = await confirmViaElicitation({
+          server,
+          toolName: "harness_execute",
+          message: `Execute "${args.action}" on ${args.resource_type}${args.resource_id ? ` "${args.resource_id}"` : ""}?`,
+        });
+        if (!elicit.proceed) {
+          return errorResult(`Operation ${elicit.reason} by user.`);
         }
 
         // Map resource_id to the primary identifier field

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -4,16 +4,16 @@ import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, toMcpError } from "../utils/errors.js";
+import { confirmViaElicitation } from "../utils/elicitation.js";
 
 export function registerUpdateTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
     "harness_update",
-    "Update an existing Harness resource. Requires confirmation=true to proceed. Response includes openInHarness link to the updated resource when applicable (e.g. pipeline, service).",
+    "Update an existing Harness resource. Response includes openInHarness link to the updated resource when applicable (e.g. pipeline, service).",
     {
       resource_type: z.string().describe("The type of resource to update (e.g. pipeline, service, environment, connector, trigger)"),
       resource_id: z.string().describe("The identifier of the resource to update"),
       body: z.record(z.string(), z.unknown()).describe("The updated resource definition body"),
-      confirmation: z.boolean().describe("Must be true to confirm the update operation").default(false),
       org_id: z.string().describe("Organization identifier (overrides default)").optional(),
       project_id: z.string().describe("Project identifier (overrides default)").optional(),
       pipeline_id: z.string().describe("Pipeline ID (for trigger updates)").optional(),
@@ -21,8 +21,13 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
     },
     async (args) => {
       try {
-        if (!args.confirmation) {
-          return errorResult("Update operations require confirmation=true. Set confirmation to true to proceed.");
+        const elicit = await confirmViaElicitation({
+          server,
+          toolName: "harness_update",
+          message: `Update ${args.resource_type} "${args.resource_id}"?\n\n${JSON.stringify(args.body, null, 2)}`,
+        });
+        if (!elicit.proceed) {
+          return errorResult(`Operation ${elicit.reason} by user.`);
         }
 
         const def = registry.getResource(args.resource_type);

--- a/src/utils/elicitation.ts
+++ b/src/utils/elicitation.ts
@@ -1,0 +1,71 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("elicitation");
+
+export interface ElicitationResult {
+  /** Whether the operation should proceed. */
+  proceed: boolean;
+  /** Why the operation was stopped, if applicable. */
+  reason?: "declined" | "cancelled";
+}
+
+/**
+ * Check whether the connected client advertises form elicitation support.
+ */
+export function clientSupportsElicitation(server: Server): boolean {
+  const caps = server.getClientCapabilities();
+  return !!caps?.elicitation?.form;
+}
+
+/**
+ * Prompt the user to confirm a write operation via MCP form elicitation.
+ *
+ * Shows a message with the operation details — the user simply accepts or
+ * declines. No form fields or checkboxes.
+ *
+ * If the client doesn't support elicitation (or the call throws),
+ * proceeds silently — the LLM already chose to call the tool.
+ */
+export async function confirmViaElicitation({
+  server,
+  toolName,
+  message,
+}: {
+  server: McpServer;
+  toolName: string;
+  message: string;
+}): Promise<ElicitationResult> {
+  if (!clientSupportsElicitation(server.server)) {
+    log.debug("Client does not support elicitation, proceeding", { toolName });
+    return { proceed: true };
+  }
+
+  try {
+    const result = await server.server.elicitInput({
+      mode: "form",
+      message,
+      requestedSchema: {
+        type: "object",
+        properties: {},
+      },
+    });
+
+    log.info("Elicitation response", { toolName, action: result.action });
+
+    if (result.action === "accept") {
+      return { proceed: true };
+    }
+    if (result.action === "decline") {
+      return { proceed: false, reason: "declined" };
+    }
+    return { proceed: false, reason: "cancelled" };
+  } catch (err) {
+    log.warn("Elicitation failed, proceeding without confirmation", {
+      toolName,
+      error: String(err),
+    });
+    return { proceed: true };
+  }
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -4,7 +4,7 @@ import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
  * Error handling convention for tool handlers:
  *
  *   return errorResult(msg)  — for user-fixable problems the LLM can act on:
- *     bad resource_type, missing confirmation, unsupported operation, missing
+ *     bad resource_type, unsupported operation, missing
  *     required fields, validation errors. These are plain Errors thrown by the
  *     registry/toolset layer. The LLM sees the message and can retry/adjust.
  *

--- a/tests/utils/elicitation.test.ts
+++ b/tests/utils/elicitation.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import { clientSupportsElicitation, confirmViaElicitation } from "../../src/utils/elicitation.js";
+
+/** Minimal stub of the Server class (only the methods we use). */
+function makeServerStub(capabilities: unknown, elicitResult?: unknown) {
+  const server = {
+    getClientCapabilities: vi.fn().mockReturnValue(capabilities),
+    elicitInput: vi.fn().mockResolvedValue(elicitResult),
+  };
+  return { server } as any;
+}
+
+describe("clientSupportsElicitation", () => {
+  it("returns false when capabilities are undefined", () => {
+    const server = { getClientCapabilities: () => undefined } as any;
+    expect(clientSupportsElicitation(server)).toBe(false);
+  });
+
+  it("returns false when elicitation is absent", () => {
+    const server = { getClientCapabilities: () => ({}) } as any;
+    expect(clientSupportsElicitation(server)).toBe(false);
+  });
+
+  it("returns false when elicitation.form is absent", () => {
+    const server = { getClientCapabilities: () => ({ elicitation: {} }) } as any;
+    expect(clientSupportsElicitation(server)).toBe(false);
+  });
+
+  it("returns true when elicitation.form is present", () => {
+    const server = { getClientCapabilities: () => ({ elicitation: { form: {} } }) } as any;
+    expect(clientSupportsElicitation(server)).toBe(true);
+  });
+});
+
+describe("confirmViaElicitation", () => {
+  it("proceeds when client does not support elicitation", async () => {
+    const mcpServer = makeServerStub(undefined);
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_delete",
+      message: "Delete pipeline?",
+    });
+    expect(result).toEqual({ proceed: true });
+    expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
+  });
+
+  it("proceeds when user accepts", async () => {
+    const mcpServer = makeServerStub(
+      { elicitation: { form: {} } },
+      { action: "accept" },
+    );
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_create",
+      message: "Create service?",
+    });
+    expect(result).toEqual({ proceed: true });
+    expect(mcpServer.server.elicitInput).toHaveBeenCalledOnce();
+  });
+
+  it("returns declined when user declines", async () => {
+    const mcpServer = makeServerStub(
+      { elicitation: { form: {} } },
+      { action: "decline" },
+    );
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_delete",
+      message: "Delete connector?",
+    });
+    expect(result).toEqual({ proceed: false, reason: "declined" });
+  });
+
+  it("returns cancelled when user cancels", async () => {
+    const mcpServer = makeServerStub(
+      { elicitation: { form: {} } },
+      { action: "cancel" },
+    );
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_execute",
+      message: "Run pipeline?",
+    });
+    expect(result).toEqual({ proceed: false, reason: "cancelled" });
+  });
+
+  it("proceeds when elicitInput throws", async () => {
+    const mcpServer = makeServerStub({ elicitation: { form: {} } });
+    mcpServer.server.elicitInput.mockRejectedValue(new Error("not implemented"));
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_delete",
+      message: "Delete service?",
+    });
+    expect(result).toEqual({ proceed: true });
+  });
+
+  it("passes message to elicitInput with empty schema", async () => {
+    const mcpServer = makeServerStub(
+      { elicitation: { form: {} } },
+      { action: "accept" },
+    );
+    await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_delete",
+      message: "Delete pipeline 'my-pipe'?",
+    });
+    const call = mcpServer.server.elicitInput.mock.calls[0][0];
+    expect(call.mode).toBe("form");
+    expect(call.message).toBe("Delete pipeline 'my-pipe'?");
+    expect(call.requestedSchema.properties).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the `confirmation: true` parameter with MCP SDK form elicitation across all 4 write tools (`harness_create`, `harness_update`, `harness_delete`, `harness_execute`)
- Clients that support elicitation get a real human-in-the-loop accept/decline dialog showing the operation details
- Clients that don't support elicitation proceed directly — the old `confirmation` param was just LLM theater anyway

## Changes
- **New**: `src/utils/elicitation.ts` — `confirmViaElicitation()` helper + `clientSupportsElicitation()` check
- **Modified**: 4 write tools — removed `confirmation` param, call `confirmViaElicitation()` before proceeding
- **Modified**: 2 prompts — removed `confirmation=true` references
- **New**: `tests/utils/elicitation.test.ts` — 10 unit tests

## Test plan
- [x] `pnpm build` compiles cleanly
- [x] `pnpm test` — all 138 tests pass
- [x] Test elicitation dialog in Cursor (client with elicitation support)
- [ ] Test passthrough in Claude Desktop / stdio (client without elicitation support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)