### PR TITLE
feat: extend harness_diagnose with structured execution reports

### DIFF
--- a/src/tools/harness-diagnose.ts
+++ b/src/tools/harness-diagnose.ts
@@ -10,27 +10,276 @@ import { applyUrlDefaults } from "../utils/url-parser.js";
 
 const log = createLogger("diagnose");
 
+// ─── Execution summary builder ───────────────────────────────────────────────
+
+interface NodeInfo {
+  nodeType?: string;
+  nodeGroup?: string;
+  nodeIdentifier?: string;
+  name?: string;
+  status?: string;
+  startTs?: number;
+  endTs?: number;
+  stepType?: string;
+  failureInfo?: { message?: string };
+  edgeLayoutList?: {
+    currentNodeChildren?: string[];
+    nextIds?: string[];
+  };
+}
+
+interface StepSummary {
+  name: string;
+  identifier: string;
+  status: string;
+  duration_ms?: number;
+  duration_human?: string;
+  failure_message?: string;
+}
+
+interface StageSummary {
+  name: string;
+  identifier: string;
+  status: string;
+  started_at?: string;
+  ended_at?: string;
+  duration_ms?: number;
+  duration_human?: string;
+  steps: StepSummary[];
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}
+
+function collectSteps(
+  layoutNodeMap: Record<string, NodeInfo>,
+  nodeId: string,
+  steps: StepSummary[],
+  visited: Set<string>,
+): void {
+  if (visited.has(nodeId)) return;
+  visited.add(nodeId);
+
+  const node = layoutNodeMap[nodeId];
+  if (!node) return;
+
+  const startTs = node.startTs;
+  const endTs = node.endTs;
+  const durationMs = startTs && endTs ? endTs - startTs : undefined;
+
+  const step: StepSummary = {
+    name: node.name ?? nodeId,
+    identifier: node.nodeIdentifier ?? nodeId,
+    status: node.status ?? "Unknown",
+    duration_ms: durationMs,
+    duration_human: durationMs != null ? formatDuration(durationMs) : undefined,
+  };
+
+  if (node.failureInfo?.message) {
+    step.failure_message = node.failureInfo.message;
+  }
+
+  steps.push(step);
+
+  // Recurse into children, then follow nextIds at the same level
+  for (const childId of node.edgeLayoutList?.currentNodeChildren ?? []) {
+    collectSteps(layoutNodeMap, childId, steps, visited);
+  }
+  for (const nextId of node.edgeLayoutList?.nextIds ?? []) {
+    collectSteps(layoutNodeMap, nextId, steps, visited);
+  }
+}
+
+function extractStages(layoutNodeMap: Record<string, NodeInfo>, startingNodeId: string): StageSummary[] {
+  const stages: StageSummary[] = [];
+  const visited = new Set<string>();
+
+  function walkNode(nodeId: string): void {
+    if (visited.has(nodeId)) return;
+    visited.add(nodeId);
+
+    const node = layoutNodeMap[nodeId];
+    if (!node) return;
+
+    if (node.nodeGroup === "STAGE") {
+      const startTs = node.startTs;
+      const endTs = node.endTs;
+      const durationMs = startTs && endTs ? endTs - startTs : undefined;
+
+      const steps: StepSummary[] = [];
+      const stepVisited = new Set<string>();
+      for (const childId of node.edgeLayoutList?.currentNodeChildren ?? []) {
+        collectSteps(layoutNodeMap, childId, steps, stepVisited);
+      }
+
+      stages.push({
+        name: node.name ?? nodeId,
+        identifier: node.nodeIdentifier ?? nodeId,
+        status: node.status ?? "Unknown",
+        started_at: startTs ? new Date(startTs).toISOString() : undefined,
+        ended_at: endTs ? new Date(endTs).toISOString() : undefined,
+        duration_ms: durationMs,
+        duration_human: durationMs != null ? formatDuration(durationMs) : undefined,
+        steps,
+      });
+    } else {
+      // Non-stage wrapper (e.g. parallel group) — recurse into children
+      for (const childId of node.edgeLayoutList?.currentNodeChildren ?? []) {
+        walkNode(childId);
+      }
+    }
+
+    // Follow next siblings
+    for (const nextId of node.edgeLayoutList?.nextIds ?? []) {
+      walkNode(nextId);
+    }
+  }
+
+  walkNode(startingNodeId);
+  return stages;
+}
+
+/**
+ * Transform the raw execution response into a structured summary report.
+ * Falls back to returning the raw data if the expected structure is missing.
+ */
+function buildExecutionSummary(execution: Record<string, unknown>): Record<string, unknown> {
+  const pes = execution.pipelineExecutionSummary as Record<string, unknown> | undefined;
+  if (!pes) return execution;
+
+  const startTs = pes.startTs as number | undefined;
+  const endTs = pes.endTs as number | undefined;
+  const durationMs = startTs && endTs ? endTs - startTs : undefined;
+  const triggerInfo = pes.executionTriggerInfo as Record<string, unknown> | undefined;
+  const triggeredBy = triggerInfo?.triggeredBy as Record<string, unknown> | undefined;
+
+  const summary: Record<string, unknown> = {
+    pipeline: {
+      name: pes.name,
+      identifier: pes.pipelineIdentifier,
+    },
+    execution: {
+      id: pes.planExecutionId,
+      status: pes.status,
+      run_sequence: pes.runSequence,
+      trigger_type: triggerInfo?.triggerType,
+      triggered_by: triggeredBy?.identifier ?? (triggeredBy?.extraInfo as Record<string, unknown> | undefined)?.email,
+    },
+    timing: {
+      started_at: startTs ? new Date(startTs).toISOString() : undefined,
+      ended_at: endTs ? new Date(endTs).toISOString() : undefined,
+      duration_ms: durationMs,
+      duration_human: durationMs != null ? formatDuration(durationMs) : undefined,
+    },
+  };
+
+  // Walk layoutNodeMap to extract stages
+  const layoutNodeMap = pes.layoutNodeMap as Record<string, NodeInfo> | undefined;
+  const startingNodeId = pes.startingNodeId as string | undefined;
+
+  if (layoutNodeMap && startingNodeId) {
+    const stages = extractStages(layoutNodeMap, startingNodeId);
+    summary.stages = stages;
+
+    // Identify failed stage and step
+    const failedStage = stages.find(
+      (s) => s.status === "Failed" || s.status === "Errored" || s.status === "Aborted",
+    );
+    if (failedStage) {
+      const failedStep = failedStage.steps.find((s) => s.failure_message);
+      summary.failure = {
+        stage: failedStage.name,
+        step: failedStep?.name,
+        error: failedStep?.failure_message,
+      };
+    }
+
+    // Identify bottleneck (longest completed stage)
+    const completedStages = stages.filter((s) => s.duration_ms != null && s.duration_ms > 0);
+    if (completedStages.length > 0 && durationMs && durationMs > 0) {
+      const bottleneck = completedStages.reduce((a, b) => (a.duration_ms! > b.duration_ms! ? a : b));
+      summary.bottleneck = {
+        stage: bottleneck.name,
+        duration_ms: bottleneck.duration_ms,
+        duration_human: bottleneck.duration_human,
+        percentage: Math.round((bottleneck.duration_ms! / durationMs) * 100),
+      };
+    }
+  }
+
+  // Preserve openInHarness from the execution response
+  if (execution.openInHarness) {
+    summary.openInHarness = execution.openInHarness;
+  }
+
+  return summary;
+}
+
+// ─── Tool registration ───────────────────────────────────────────────────────
+
 export function registerDiagnoseTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   server.tool(
     "harness_diagnose",
-    "Diagnose a pipeline execution failure. You can pass a Harness execution URL to auto-extract the execution ID, org, and project. Aggregates execution details, pipeline YAML, and execution logs into a single diagnostic payload.",
+    "Analyze a pipeline execution — returns a structured report with stage breakdown, timing, bottlenecks, and failure info. Accepts an execution_id, a pipeline_id (auto-fetches latest execution), or a Harness URL. Set summary=false for raw diagnostic data with pipeline YAML and execution logs.",
     {
-      execution_id: z.string().describe("The pipeline execution ID to diagnose. Auto-detected from url if provided.").optional(),
-      url: z.string().describe("A Harness execution URL — execution ID, org, and project are extracted automatically").optional(),
+      execution_id: z.string().describe("The pipeline execution ID to analyze. Auto-detected from url if provided.").optional(),
+      pipeline_id: z.string().describe("Pipeline identifier — fetches the latest execution automatically when no execution_id is given. Auto-detected from url if provided.").optional(),
+      url: z.string().describe("A Harness execution or pipeline URL — identifiers are extracted automatically").optional(),
       org_id: z.string().describe("Organization identifier (overrides default)").optional(),
       project_id: z.string().describe("Project identifier (overrides default)").optional(),
-      include_yaml: z.boolean().describe("Include the full pipeline YAML definition").default(true).optional(),
-      include_logs: z.boolean().describe("Include execution step logs").default(true).optional(),
+      summary: z.boolean().describe("Return structured summary report (default true). Set to false for raw diagnostic payload with YAML and logs.").default(true).optional(),
+      include_yaml: z.boolean().describe("Include pipeline YAML definition. Defaults to false in summary mode, true in diagnostic mode.").optional(),
+      include_logs: z.boolean().describe("Include execution step logs. Defaults to false in summary mode, true in diagnostic mode.").optional(),
     },
     async (args, extra) => {
       try {
         const input = applyUrlDefaults(args as Record<string, unknown>, args.url);
-        const executionId = input.execution_id as string | undefined;
-        if (!executionId) {
-          return errorResult("execution_id is required. Provide it explicitly or via a Harness execution URL.");
+        let executionId = input.execution_id as string | undefined;
+        const pipelineId = input.pipeline_id as string | undefined;
+        const isSummary = args.summary !== false;
+
+        // Determine include defaults based on mode
+        const includeYaml = args.include_yaml ?? !isSummary;
+        const includeLogs = args.include_logs ?? !isSummary;
+
+        // Auto-fetch latest execution if pipeline_id provided without execution_id
+        if (!executionId && pipelineId) {
+          log.info("Fetching latest execution for pipeline", { pipelineId });
+          await sendProgress(extra, 0, 3, "Fetching latest execution...");
+          try {
+            const execList = await registry.dispatch(client, "execution", "list", {
+              ...input,
+              pipeline_id: pipelineId,
+              size: 1,
+              page: 0,
+            });
+            const items = (execList as { items?: Array<Record<string, unknown>> }).items;
+            if (items && items.length > 0) {
+              executionId = (items[0].planExecutionId as string) ?? undefined;
+              input.execution_id = executionId;
+            }
+          } catch (err) {
+            log.warn("Failed to fetch latest execution", { error: String(err) });
+          }
         }
+
+        if (!executionId) {
+          return errorResult(
+            "execution_id or pipeline_id is required. Provide either explicitly or via a Harness URL.",
+          );
+        }
+
         const diagnostic: Record<string, unknown> = {};
-        const totalSteps = 1 + (args.include_yaml !== false ? 1 : 0) + (args.include_logs !== false ? 1 : 0);
+        const totalSteps = 1 + (includeYaml ? 1 : 0) + (includeLogs ? 1 : 0);
         let step = 0;
 
         // 1. Get execution details
@@ -38,22 +287,28 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
         log.info("Fetching execution details", { executionId });
         try {
           const execution = await registry.dispatch(client, "execution", "get", input);
-          diagnostic.execution = execution;
 
-          // Extract pipeline ID from execution if available
+          // Apply summary transformation or return raw
+          if (isSummary) {
+            diagnostic.execution = buildExecutionSummary(execution as Record<string, unknown>);
+          } else {
+            diagnostic.execution = execution;
+          }
+
+          // Extract pipeline ID from execution for YAML fetch
           const exec = execution as Record<string, unknown>;
           const pipelineExec = exec?.pipelineExecutionSummary as Record<string, unknown> | undefined;
-          const pipelineId = pipelineExec?.pipelineIdentifier as string | undefined;
+          const resolvedPipelineId = pipelineExec?.pipelineIdentifier as string | undefined;
 
           step++;
 
-          // 2. Get pipeline YAML if requested and pipeline ID available
-          if (args.include_yaml !== false && pipelineId) {
+          // 2. Get pipeline YAML if requested
+          if (includeYaml && resolvedPipelineId) {
             await sendProgress(extra, step, totalSteps, "Fetching pipeline YAML...");
             try {
               const pipeline = await registry.dispatch(client, "pipeline", "get", {
                 ...input,
-                pipeline_id: pipelineId,
+                pipeline_id: resolvedPipelineId,
               });
               diagnostic.pipeline = pipeline;
             } catch (err) {
@@ -66,7 +321,7 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
         }
 
         // 3. Get execution logs if requested
-        if (args.include_logs !== false) {
+        if (includeLogs) {
           step++;
           await sendProgress(extra, step, totalSteps, "Fetching execution logs...");
           try {
@@ -78,7 +333,7 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
           }
         }
 
-        await sendProgress(extra, totalSteps, totalSteps, "Diagnosis complete");
+        await sendProgress(extra, totalSteps, totalSteps, isSummary ? "Report complete" : "Diagnosis complete");
         return jsonResult(diagnostic);
       } catch (err) {
         if (isUserError(err)) return errorResult(err.message);


### PR DESCRIPTION
## Summary
- `harness_diagnose` now serves dual purpose: **execution report** (default) and **failure diagnostic**
- Default mode (`summary=true`): returns structured report with stage breakdown, timing, bottleneck identification, and failure info
- Diagnostic mode (`summary=false`): preserves existing behavior (raw data + YAML + logs)
- Accepts `pipeline_id` to auto-fetch the latest execution (covers "analyze latest pipeline" use case)
- `include_yaml`/`include_logs` default to `false` in summary mode, `true` in diagnostic mode

## Example output (summary mode)
```json
{
  "pipeline": { "name": "Deploy", "identifier": "deploy_prod" },
  "execution": { "id": "abc123", "status": "Success", "run_sequence": 42 },
  "timing": { "started_at": "...", "duration_ms": 138000, "duration_human": "2m 18s" },
  "stages": [
    { "name": "Build", "status": "Success", "duration_human": "1m 5s", "steps": [...] },
    { "name": "Deploy", "status": "Success", "duration_human": "45s", "steps": [...] }
  ],
  "bottleneck": { "stage": "Build", "percentage": 72 },
  "openInHarness": "https://..."
}
```

## Test plan
- [x] TypeScript build passes
- [x] Full test suite passes (167 tests)
- [x] Manual test with live Harness execution URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)