### PR TITLE
fix: validate resource_type before eliciting user confirmation

### DIFF
--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -21,6 +21,13 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
     async (args) => {
       try {
         const input = applyUrlDefaults(args as Record<string, unknown>, args.url);
+
+        // Validate resource_type and operation before asking user to confirm
+        const def = registry.getResource(args.resource_type);
+        if (!def.operations.create) {
+          return errorResult(`Resource "${args.resource_type}" does not support "create". Supported: ${Object.keys(def.operations).join(", ")}`);
+        }
+
         const elicit = await confirmViaElicitation({
           server,
           toolName: "harness_create",

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -21,6 +21,12 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
     },
     async (args) => {
       try {
+        // Validate resource_type and operation before asking user to confirm
+        const def = registry.getResource(args.resource_type);
+        if (!def.operations.delete) {
+          return errorResult(`Resource "${args.resource_type}" does not support "delete". Supported: ${Object.keys(def.operations).join(", ")}`);
+        }
+
         const elicit = await confirmViaElicitation({
           server,
           toolName: "harness_delete",
@@ -29,8 +35,6 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);
         }
-
-        const def = registry.getResource(args.resource_type);
         const { params, ...rest } = args;
         const input = applyUrlDefaults(rest as Record<string, unknown>, args.url);
         if (params) Object.assign(input, params);

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -36,6 +36,13 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         }
         const resourceId = input.resource_id as string | undefined;
 
+        // Validate resource_type and action before asking user to confirm
+        const def = registry.getResource(resourceType);
+        if (!def.executeActions?.[args.action]) {
+          const available = def.executeActions ? Object.keys(def.executeActions).join(", ") : "none";
+          return errorResult(`Resource "${resourceType}" has no execute action "${args.action}". Available: ${available}`);
+        }
+
         const elicit = await confirmViaElicitation({
           server,
           toolName: "harness_execute",
@@ -46,7 +53,6 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         }
 
         // Map resource_id to the primary identifier field
-        const def = registry.getResource(resourceType);
         if (def.identifierFields.length > 0 && resourceId) {
           input[def.identifierFields[0]] = resourceId;
         }

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -22,6 +22,12 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
     },
     async (args) => {
       try {
+        // Validate resource_type and operation before asking user to confirm
+        const def = registry.getResource(args.resource_type);
+        if (!def.operations.update) {
+          return errorResult(`Resource "${args.resource_type}" does not support "update". Supported: ${Object.keys(def.operations).join(", ")}`);
+        }
+
         const elicit = await confirmViaElicitation({
           server,
           toolName: "harness_update",
@@ -30,8 +36,6 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);
         }
-
-        const def = registry.getResource(args.resource_type);
         const { params, ...rest } = args;
         const input = applyUrlDefaults(rest as Record<string, unknown>, args.url);
         if (params) Object.assign(input, params);


### PR DESCRIPTION
## Summary
- All 4 write tools (`harness_create`, `harness_update`, `harness_delete`, `harness_execute`) were asking the user to confirm **before** validating that the resource_type/operation/action exists
- Users would confirm, then get "unknown resource type" or "unsupported operation" errors
- Fix: move `registry.getResource()` and operation validation **before** `confirmViaElicitation()`

## What changed
- `harness_create`: validate resource_type + create operation exists → then elicit
- `harness_update`: validate resource_type + update operation exists → then elicit
- `harness_delete`: validate resource_type + delete operation exists → then elicit
- `harness_execute`: validate resource_type + action exists → then elicit

## Test plan
- [x] All 223 tests pass
- [x] Clean `tsc` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)