### PR TITLE
fix: block destructive operations when confirmation unavailable

### DIFF
--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -31,6 +31,7 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
           server,
           toolName: "harness_delete",
           message: `Delete ${args.resource_type} "${args.resource_id}"?\n\nThis is destructive and cannot be undone.`,
+          destructive: true,
         });
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);

--- a/src/utils/elicitation.ts
+++ b/src/utils/elicitation.ts
@@ -25,19 +25,27 @@ export function clientSupportsElicitation(server: Server): boolean {
  * Shows a message with the operation details — the user simply accepts or
  * declines. No form fields or checkboxes.
  *
- * If the client doesn't support elicitation (or the call throws),
- * proceeds silently — the LLM already chose to call the tool.
+ * When `destructive` is true (e.g. deletes), the operation is **blocked** if
+ * the client doesn't support elicitation or the elicitation call fails.
+ * Non-destructive writes proceed silently in those cases.
  */
 export async function confirmViaElicitation({
   server,
   toolName,
   message,
+  destructive = false,
 }: {
   server: McpServer;
   toolName: string;
   message: string;
+  /** When true, block the operation if confirmation cannot be obtained. */
+  destructive?: boolean;
 }): Promise<ElicitationResult> {
   if (!clientSupportsElicitation(server.server)) {
+    if (destructive) {
+      log.warn("Client does not support elicitation, blocking destructive operation", { toolName });
+      return { proceed: false, reason: "declined" };
+    }
     log.debug("Client does not support elicitation, proceeding", { toolName });
     return { proceed: true };
   }
@@ -62,6 +70,13 @@ export async function confirmViaElicitation({
     }
     return { proceed: false, reason: "cancelled" };
   } catch (err) {
+    if (destructive) {
+      log.warn("Elicitation failed, blocking destructive operation", {
+        toolName,
+        error: String(err),
+      });
+      return { proceed: false, reason: "cancelled" };
+    }
     log.warn("Elicitation failed, proceeding without confirmation", {
       toolName,
       error: String(err),

--- a/tests/utils/elicitation.test.ts
+++ b/tests/utils/elicitation.test.ts
@@ -33,14 +33,26 @@ describe("clientSupportsElicitation", () => {
 });
 
 describe("confirmViaElicitation", () => {
-  it("proceeds when client does not support elicitation", async () => {
+  it("proceeds when client does not support elicitation (non-destructive)", async () => {
+    const mcpServer = makeServerStub(undefined);
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_create",
+      message: "Create pipeline?",
+    });
+    expect(result).toEqual({ proceed: true });
+    expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
+  });
+
+  it("blocks when client does not support elicitation (destructive)", async () => {
     const mcpServer = makeServerStub(undefined);
     const result = await confirmViaElicitation({
       server: mcpServer,
       toolName: "harness_delete",
       message: "Delete pipeline?",
+      destructive: true,
     });
-    expect(result).toEqual({ proceed: true });
+    expect(result).toEqual({ proceed: false, reason: "declined" });
     expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
   });
 
@@ -84,15 +96,27 @@ describe("confirmViaElicitation", () => {
     expect(result).toEqual({ proceed: false, reason: "cancelled" });
   });
 
-  it("proceeds when elicitInput throws", async () => {
+  it("proceeds when elicitInput throws (non-destructive)", async () => {
+    const mcpServer = makeServerStub({ elicitation: { form: {} } });
+    mcpServer.server.elicitInput.mockRejectedValue(new Error("not implemented"));
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_create",
+      message: "Create service?",
+    });
+    expect(result).toEqual({ proceed: true });
+  });
+
+  it("blocks when elicitInput throws (destructive)", async () => {
     const mcpServer = makeServerStub({ elicitation: { form: {} } });
     mcpServer.server.elicitInput.mockRejectedValue(new Error("not implemented"));
     const result = await confirmViaElicitation({
       server: mcpServer,
       toolName: "harness_delete",
       message: "Delete service?",
+      destructive: true,
     });
-    expect(result).toEqual({ proceed: true });
+    expect(result).toEqual({ proceed: false, reason: "cancelled" });
   });
 
   it("passes message to elicitInput with empty schema", async () => {


### PR DESCRIPTION
## Summary
- Unsupported clients and failed elicitation both silently proceeded — deletes could execute without user confirmation
- Added `destructive` flag to `confirmViaElicitation()` — when true, blocks if confirmation can't be obtained
- `harness_delete` now passes `destructive: true`, so deletes are blocked by default on clients that don't support elicitation (e.g. Cursor)
- Non-destructive writes (create, update, execute) still proceed silently when elicitation is unavailable

## Behavior matrix

| Scenario | `destructive: false` (default) | `destructive: true` |
|----------|-------------------------------|---------------------|
| Client doesn't support elicitation | proceed | **block** |
| Elicitation call throws | proceed | **block** |
| User accepts | proceed | proceed |
| User declines/cancels | block | block |

## Changed files
- `src/utils/elicitation.ts`: add `destructive` param, branch on it for unsupported/failed paths
- `src/tools/harness-delete.ts`: pass `destructive: true`
- `tests/utils/elicitation.test.ts`: 2 new tests for destructive blocking paths

## Test plan
- [x] 225 tests pass (2 new)
- [x] Clean `tsc` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)