### PR TITLE
refactor: migrate to registerTool/registerPrompt with tool annotations

### DIFF
--- a/src/prompts/access-control-audit.ts
+++ b/src/prompts/access-control-audit.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerAccessControlAuditPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "access-control-audit",
-    "Audit user permissions, over-privileged accounts, and role assignments to enforce least-privilege",
     {
-      projectId: z.string().describe("Project identifier").optional(),
-      orgId: z.string().describe("Organization identifier").optional(),
+      description: "Audit user permissions, over-privileged accounts, and role assignments to enforce least-privilege",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier").optional(),
+        orgId: z.string().describe("Organization identifier").optional(),
+      },
     },
     async ({ projectId, orgId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/branch-cleanup.ts
+++ b/src/prompts/branch-cleanup.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerBranchCleanupPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "branch-cleanup",
-    "Analyze branches in a repository and recommend stale or merged branches to delete",
     {
-      repoId: z.string().describe("Repository identifier"),
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Analyze branches in a repository and recommend stale or merged branches to delete",
+      argsSchema: {
+        repoId: z.string().describe("Repository identifier"),
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ repoId, projectId }) => {
       const projectArg = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/build-deploy-app.ts
+++ b/src/prompts/build-deploy-app.ts
@@ -2,14 +2,16 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerBuildDeployAppPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "build-deploy-app",
-    "End-to-end workflow: scan a repo, generate CI/CD pipelines in Harness, build a Docker image, generate K8s manifests, and deploy",
     {
-      repoUrl: z.string().describe("Git repository URL (e.g. https://github.com/org/repo)"),
-      imageName: z.string().describe("Docker image name including registry (e.g. docker.io/myorg/myapp)"),
-      projectId: z.string().describe("Harness project identifier").optional(),
-      namespace: z.string().describe("Kubernetes namespace for deployment").optional(),
+      description: "End-to-end workflow: scan a repo, generate CI/CD pipelines in Harness, build a Docker image, generate K8s manifests, and deploy",
+      argsSchema: {
+        repoUrl: z.string().describe("Git repository URL (e.g. https://github.com/org/repo)"),
+        imageName: z.string().describe("Docker image name including registry (e.g. docker.io/myorg/myapp)"),
+        projectId: z.string().describe("Harness project identifier").optional(),
+        namespace: z.string().describe("Kubernetes namespace for deployment").optional(),
+      },
     },
     async ({ repoUrl, imageName, projectId, namespace }) => ({
       messages: [{

--- a/src/prompts/chaos-resilience.ts
+++ b/src/prompts/chaos-resilience.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerChaosResiliencePrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "chaos-resilience-test",
-    "Design and run a chaos experiment to test service resilience",
     {
-      serviceName: z.string().describe("Name of the service to test"),
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Design and run a chaos experiment to test service resilience",
+      argsSchema: {
+        serviceName: z.string().describe("Name of the service to test"),
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ serviceName, projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/cloud-cost-breakdown.ts
+++ b/src/prompts/cloud-cost-breakdown.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerCloudCostBreakdownPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "cloud-cost-breakdown",
-    "Deep-dive into cloud costs by service, environment, or cluster with trend analysis",
     {
-      perspectiveId: z.string().describe("Cost perspective ID to analyze").optional(),
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Deep-dive into cloud costs by service, environment, or cluster with trend analysis",
+      argsSchema: {
+        perspectiveId: z.string().describe("Cost perspective ID to analyze").optional(),
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ perspectiveId, projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/code-review.ts
+++ b/src/prompts/code-review.ts
@@ -2,13 +2,15 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerCodeReviewPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "code-review",
-    "Review a Harness Code pull request — analyze diff, commits, checks, and comments to provide structured feedback",
     {
-      repoId: z.string().describe("Repository identifier"),
-      prNumber: z.string().describe("Pull request number"),
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Review a Harness Code pull request — analyze diff, commits, checks, and comments to provide structured feedback",
+      argsSchema: {
+        repoId: z.string().describe("Repository identifier"),
+        prNumber: z.string().describe("Pull request number"),
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ repoId, prNumber, projectId }) => {
       const projectArg = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/commitment-utilization.ts
+++ b/src/prompts/commitment-utilization.ts
@@ -2,11 +2,13 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerCommitmentUtilizationPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "commitment-utilization-review",
-    "Analyze reserved instance and savings plan utilization to find waste and optimize commitments",
     {
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Analyze reserved instance and savings plan utilization to find waste and optimize commitments",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/cost-anomaly.ts
+++ b/src/prompts/cost-anomaly.ts
@@ -2,11 +2,13 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerCostAnomalyPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "cost-anomaly-investigation",
-    "Investigate cost anomalies — determine root cause, impacted resources, and remediation",
     {
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Investigate cost anomalies — determine root cause, impacted resources, and remediation",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/create-pipeline.ts
+++ b/src/prompts/create-pipeline.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerCreatePipelinePrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "create-pipeline",
-    "Generate a new Harness pipeline YAML from requirements",
     {
-      description: z.string().describe("Describe what the pipeline should do"),
-      projectId: z.string().describe("Target project identifier").optional(),
+      description: "Generate a new Harness pipeline YAML from requirements",
+      argsSchema: {
+        description: z.string().describe("Describe what the pipeline should do"),
+        projectId: z.string().describe("Target project identifier").optional(),
+      },
     },
     async ({ description, projectId }) => ({
       messages: [{

--- a/src/prompts/debug-pipeline.ts
+++ b/src/prompts/debug-pipeline.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerDebugPipelinePrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "debug-pipeline-failure",
-    "Analyze a failed pipeline execution and suggest fixes. Accepts an execution ID, pipeline ID, or Harness URL.",
     {
-      executionId: z.string().describe("The failed execution ID, pipeline ID, or a Harness URL").optional(),
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Analyze a failed pipeline execution and suggest fixes. Accepts an execution ID, pipeline ID, or Harness URL.",
+      argsSchema: {
+        executionId: z.string().describe("The failed execution ID, pipeline ID, or a Harness URL").optional(),
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ executionId, projectId }) => {
       // Detect if the input looks like a URL

--- a/src/prompts/delegate-health.ts
+++ b/src/prompts/delegate-health.ts
@@ -2,11 +2,13 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerDelegateHealthPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "delegate-health-check",
-    "Check delegate connectivity, health, and token status with troubleshooting guidance",
     {
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Check delegate connectivity, health, and token status with troubleshooting guidance",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/developer-scorecard.ts
+++ b/src/prompts/developer-scorecard.ts
@@ -2,11 +2,13 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerDeveloperScorecardPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "developer-portal-scorecard",
-    "Review IDP scorecards for services and identify gaps to improve developer experience",
     {
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Review IDP scorecards for services and identify gaps to improve developer experience",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/dora-metrics.ts
+++ b/src/prompts/dora-metrics.ts
@@ -2,13 +2,15 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerDoraMetricsPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "dora-metrics-review",
-    "Review DORA metrics (deployment frequency, change failure rate, MTTR, lead time) and suggest improvements",
     {
-      teamRefId: z.string().describe("SEI team reference ID to analyze").optional(),
-      dateStart: z.string().describe("Start date for analysis (YYYY-MM-DD)").optional(),
-      dateEnd: z.string().describe("End date for analysis (YYYY-MM-DD)").optional(),
+      description: "Review DORA metrics (deployment frequency, change failure rate, MTTR, lead time) and suggest improvements",
+      argsSchema: {
+        teamRefId: z.string().describe("SEI team reference ID to analyze").optional(),
+        dateStart: z.string().describe("Start date for analysis (YYYY-MM-DD)").optional(),
+        dateEnd: z.string().describe("End date for analysis (YYYY-MM-DD)").optional(),
+      },
     },
     async ({ teamRefId, dateStart, dateEnd }) => {
       const teamFilter = teamRefId ? `, team_ref_id="${teamRefId}"` : "";

--- a/src/prompts/exemption-review.ts
+++ b/src/prompts/exemption-review.ts
@@ -2,11 +2,13 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerExemptionReviewPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "security-exemption-review",
-    "Review pending security exemptions and make batch approval or rejection decisions",
     {
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Review pending security exemptions and make batch approval or rejection decisions",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/feature-flag-rollout.ts
+++ b/src/prompts/feature-flag-rollout.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerFeatureFlagRolloutPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "feature-flag-rollout",
-    "Plan and execute a progressive feature flag rollout across environments",
     {
-      flagIdentifier: z.string().describe("Feature flag identifier to roll out"),
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Plan and execute a progressive feature flag rollout across environments",
+      argsSchema: {
+        flagIdentifier: z.string().describe("Feature flag identifier to roll out"),
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ flagIdentifier, projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/migrate-to-template.ts
+++ b/src/prompts/migrate-to-template.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerMigrateToTemplatePrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "migrate-pipeline-to-template",
-    "Analyze an existing pipeline and extract reusable stage/step templates from it",
     {
-      pipelineId: z.string().describe("Pipeline identifier to analyze"),
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Analyze an existing pipeline and extract reusable stage/step templates from it",
+      argsSchema: {
+        pipelineId: z.string().describe("Pipeline identifier to analyze"),
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ pipelineId, projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/onboard-service.ts
+++ b/src/prompts/onboard-service.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerOnboardServicePrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "onboard-service",
-    "Walk through onboarding a new service into Harness with environments and a deployment pipeline",
     {
-      serviceName: z.string().describe("Name of the service to onboard"),
-      projectId: z.string().describe("Target project identifier").optional(),
+      description: "Walk through onboarding a new service into Harness with environments and a deployment pipeline",
+      argsSchema: {
+        serviceName: z.string().describe("Name of the service to onboard"),
+        projectId: z.string().describe("Target project identifier").optional(),
+      },
     },
     async ({ serviceName, projectId }) => ({
       messages: [{

--- a/src/prompts/optimize-costs.ts
+++ b/src/prompts/optimize-costs.ts
@@ -2,11 +2,13 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerOptimizeCostsPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "optimize-costs",
-    "Analyze cloud cost data and recommend optimizations for a Harness project",
     {
-      projectId: z.string().describe("Project identifier to analyze costs for").optional(),
+      description: "Analyze cloud cost data and recommend optimizations for a Harness project",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier to analyze costs for").optional(),
+      },
     },
     async ({ projectId }) => ({
       messages: [{

--- a/src/prompts/pending-approvals.ts
+++ b/src/prompts/pending-approvals.ts
@@ -2,13 +2,15 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerPendingApprovalsPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "pending-approvals",
-    "Find pipeline executions waiting for approval and present them for action",
     {
-      projectId: z.string().describe("Project identifier").optional(),
-      orgId: z.string().describe("Organization identifier").optional(),
-      pipelineId: z.string().describe("Filter to a specific pipeline").optional(),
+      description: "Find pipeline executions waiting for approval and present them for action",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier").optional(),
+        orgId: z.string().describe("Organization identifier").optional(),
+        pipelineId: z.string().describe("Filter to a specific pipeline").optional(),
+      },
     },
     async ({ projectId, orgId, pipelineId }) => ({
       messages: [{

--- a/src/prompts/pr-summary.ts
+++ b/src/prompts/pr-summary.ts
@@ -2,14 +2,16 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerPrSummaryPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "pr-summary",
-    "Auto-generate a pull request title and description from the commit history and diff of a branch",
     {
-      repoId: z.string().describe("Repository identifier"),
-      sourceBranch: z.string().describe("Source branch name (the feature branch)"),
-      targetBranch: z.string().describe("Target branch name (e.g., main)").optional(),
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Auto-generate a pull request title and description from the commit history and diff of a branch",
+      argsSchema: {
+        repoId: z.string().describe("Repository identifier"),
+        sourceBranch: z.string().describe("Source branch name (the feature branch)"),
+        targetBranch: z.string().describe("Target branch name (e.g., main)").optional(),
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ repoId, sourceBranch, targetBranch, projectId }) => {
       const target = targetBranch ?? "main";

--- a/src/prompts/rightsizing.ts
+++ b/src/prompts/rightsizing.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerRightsizingPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "rightsizing-recommendations",
-    "Review and prioritize rightsizing recommendations, optionally create Jira or ServiceNow tickets",
     {
-      projectId: z.string().describe("Project identifier").optional(),
-      minSavings: z.string().describe("Minimum monthly savings threshold to include (e.g., '100' for $100/mo)").optional(),
+      description: "Review and prioritize rightsizing recommendations, optionally create Jira or ServiceNow tickets",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier").optional(),
+        minSavings: z.string().describe("Minimum monthly savings threshold to include (e.g., '100' for $100/mo)").optional(),
+      },
     },
     async ({ projectId, minSavings }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/sbom-compliance.ts
+++ b/src/prompts/sbom-compliance.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerSbomCompliancePrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "sbom-compliance-check",
-    "Audit SBOM and compliance posture for artifacts — license risks, policy violations, component vulnerabilities",
     {
-      artifactId: z.string().describe("Specific artifact ID to audit").optional(),
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Audit SBOM and compliance posture for artifacts — license risks, policy violations, component vulnerabilities",
+      argsSchema: {
+        artifactId: z.string().describe("Specific artifact ID to audit").optional(),
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ artifactId, projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/security-review.ts
+++ b/src/prompts/security-review.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerSecurityReviewPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "security-review",
-    "Review security issues across Harness resources and suggest remediations",
     {
-      projectId: z.string().describe("Project identifier to review").optional(),
-      severity: z.string().describe("Comma-separated severity filter (default: critical,high)").optional(),
+      description: "Review security issues across Harness resources and suggest remediations",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier to review").optional(),
+        severity: z.string().describe("Comma-separated severity filter (default: critical,high)").optional(),
+      },
     },
     async ({ projectId, severity }) => {
       const severityFilter = severity ?? "critical,high";

--- a/src/prompts/setup-gitops.ts
+++ b/src/prompts/setup-gitops.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerSetupGitopsPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "setup-gitops-application",
-    "Guide through onboarding a GitOps application — verify agent, cluster, repo, and create the application",
     {
-      agentId: z.string().describe("GitOps agent identifier"),
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "Guide through onboarding a GitOps application — verify agent, cluster, repo, and create the application",
+      argsSchema: {
+        agentId: z.string().describe("GitOps agent identifier"),
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ agentId, projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/supply-chain-audit.ts
+++ b/src/prompts/supply-chain-audit.ts
@@ -2,11 +2,13 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerSupplyChainAuditPrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "supply-chain-audit",
-    "End-to-end software supply chain security audit — provenance, chain of custody, policy compliance",
     {
-      projectId: z.string().describe("Project identifier").optional(),
+      description: "End-to-end software supply chain security audit — provenance, chain of custody, policy compliance",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier").optional(),
+      },
     },
     async ({ projectId }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/prompts/vulnerability-triage.ts
+++ b/src/prompts/vulnerability-triage.ts
@@ -2,12 +2,14 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function registerVulnerabilityTriagePrompt(server: McpServer): void {
-  server.prompt(
+  server.registerPrompt(
     "vulnerability-triage",
-    "Triage security vulnerabilities across pipelines and artifacts, prioritize by severity and exploitability",
     {
-      projectId: z.string().describe("Project identifier").optional(),
-      severity: z.string().describe("Severity filter: critical, high, medium, low (comma-separated)").optional(),
+      description: "Triage security vulnerabilities across pipelines and artifacts, prioritize by severity and exploitability",
+      argsSchema: {
+        projectId: z.string().describe("Project identifier").optional(),
+        severity: z.string().describe("Severity filter: critical, high, medium, low (comma-separated)").optional(),
+      },
     },
     async ({ projectId, severity }) => {
       const projectFilter = projectId ? `, project_id="${projectId}"` : "";

--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -8,15 +8,24 @@ import { confirmViaElicitation } from "../utils/elicitation.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 
 export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient): void {
-  server.tool(
+  server.registerTool(
     "harness_create",
-    "Create a new Harness resource. You can pass a Harness URL to auto-extract org and project scope. For pipelines, templates, and triggers — read the schema resource first (e.g. schema:///pipeline) to understand the required body format.",
     {
-      resource_type: z.string().describe("The type of resource to create (e.g. pipeline, service, environment, connector, trigger)"),
-      body: z.record(z.string(), z.unknown()).describe("The resource definition body (varies by resource type — typically the YAML or JSON spec)"),
-      url: z.string().describe("A Harness UI URL — org and project are extracted automatically").optional(),
-      org_id: z.string().describe("Organization identifier (overrides default)").optional(),
-      project_id: z.string().describe("Project identifier (overrides default)").optional(),
+      description: "Create a new Harness resource. You can pass a Harness URL to auto-extract org and project scope. For pipelines, templates, and triggers — read the schema resource first (e.g. schema:///pipeline) to understand the required body format.",
+      inputSchema: {
+        resource_type: z.string().describe("The type of resource to create (e.g. pipeline, service, environment, connector, trigger)"),
+        body: z.record(z.string(), z.unknown()).describe("The resource definition body (varies by resource type — typically the YAML or JSON spec)"),
+        url: z.string().describe("A Harness UI URL — org and project are extracted automatically").optional(),
+        org_id: z.string().describe("Organization identifier (overrides default)").optional(),
+        project_id: z.string().describe("Project identifier (overrides default)").optional(),
+      },
+      annotations: {
+        title: "Create Harness Resource",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
     async (args) => {
       try {

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -8,16 +8,25 @@ import { confirmViaElicitation } from "../utils/elicitation.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 
 export function registerDeleteTool(server: McpServer, registry: Registry, client: HarnessClient): void {
-  server.tool(
+  server.registerTool(
     "harness_delete",
-    "Delete a Harness resource. You can pass a Harness URL to auto-extract identifiers. This is destructive and cannot be undone.",
     {
-      resource_type: z.string().describe("The type of resource to delete (e.g. pipeline, trigger, connector)"),
-      resource_id: z.string().describe("The identifier of the resource to delete"),
-      url: z.string().describe("A Harness UI URL — org, project, resource type, and ID are extracted automatically").optional(),
-      org_id: z.string().describe("Organization identifier (overrides default)").optional(),
-      project_id: z.string().describe("Project identifier (overrides default)").optional(),
-      params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources (e.g. pipeline_id for triggers, environment_id for infrastructure).").optional(),
+      description: "Delete a Harness resource. You can pass a Harness URL to auto-extract identifiers. This is destructive and cannot be undone.",
+      inputSchema: {
+        resource_type: z.string().describe("The type of resource to delete (e.g. pipeline, trigger, connector)"),
+        resource_id: z.string().describe("The identifier of the resource to delete"),
+        url: z.string().describe("A Harness UI URL — org, project, resource type, and ID are extracted automatically").optional(),
+        org_id: z.string().describe("Organization identifier (overrides default)").optional(),
+        project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources (e.g. pipeline_id for triggers, environment_id for infrastructure).").optional(),
+      },
+      annotations: {
+        title: "Delete Harness Resource",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
     },
     async (args) => {
       try {

--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -4,13 +4,20 @@ import type { Registry } from "../registry/index.js";
 import { jsonResult } from "../utils/response-formatter.js";
 
 export function registerDescribeTool(server: McpServer, registry: Registry): void {
-  server.tool(
+  server.registerTool(
     "harness_describe",
-    "Describe available Harness resource types, their supported operations, and fields. No API call — returns local metadata only. Use this to discover what resource_types you can use with other harness_ tools.",
     {
-      resource_type: z.string().describe("Get details for a specific resource type").optional(),
-      toolset: z.string().describe("Filter to a specific toolset (e.g. pipelines, services)").optional(),
-      search_term: z.string().describe("Search for resource types by keyword (matches type name, display name, toolset, description)").optional(),
+      description: "Describe available Harness resource types, their supported operations, and fields. No API call — returns local metadata only. Use this to discover what resource_types you can use with other harness_ tools.",
+      inputSchema: {
+        resource_type: z.string().describe("Get details for a specific resource type").optional(),
+        toolset: z.string().describe("Filter to a specific toolset (e.g. pipelines, services)").optional(),
+        search_term: z.string().describe("Search for resource types by keyword (matches type name, display name, toolset, description)").optional(),
+      },
+      annotations: {
+        title: "Describe Harness Resources",
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
     },
     async (args) => {
       if (args.resource_type) {

--- a/src/tools/harness-diagnose.ts
+++ b/src/tools/harness-diagnose.ts
@@ -24,16 +24,23 @@ const handlers: Record<string, DiagnoseHandler> = {
 const SUPPORTED_TYPES = Object.keys(handlers).join(", ");
 
 export function registerDiagnoseTool(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
-  server.tool(
+  server.registerTool(
     "harness_diagnose",
-    `Diagnose a Harness resource — analyze failures, test connectivity, check health, or troubleshoot GitOps sync issues. Supported resource_types: ${SUPPORTED_TYPES}. Defaults to pipeline execution diagnosis. Accepts a Harness URL to auto-detect the resource type.`,
     {
-      resource_type: z.string().describe(`Resource type to diagnose: ${SUPPORTED_TYPES}. Auto-detected from url if provided. Defaults to pipeline.`).optional(),
-      resource_id: z.string().describe("Primary identifier of the resource (connector ID, delegate name). Auto-detected from url if provided.").optional(),
-      url: z.string().describe("A Harness URL — resource type, org, project, and ID are extracted automatically").optional(),
-      org_id: z.string().describe("Organization identifier (overrides default)").optional(),
-      project_id: z.string().describe("Project identifier (overrides default)").optional(),
-      options: z.record(z.string(), z.unknown()).describe("Resource-specific diagnostic options. Pipeline: execution_id, pipeline_id, summary, include_yaml, include_logs, log_snippet_lines, max_failed_steps. GitOps: agent_id. Call harness_describe for details.").optional(),
+      description: `Diagnose a Harness resource — analyze failures, test connectivity, check health, or troubleshoot GitOps sync issues. Supported resource_types: ${SUPPORTED_TYPES}. Defaults to pipeline execution diagnosis. Accepts a Harness URL to auto-detect the resource type.`,
+      inputSchema: {
+        resource_type: z.string().describe(`Resource type to diagnose: ${SUPPORTED_TYPES}. Auto-detected from url if provided. Defaults to pipeline.`).optional(),
+        resource_id: z.string().describe("Primary identifier of the resource (connector ID, delegate name). Auto-detected from url if provided.").optional(),
+        url: z.string().describe("A Harness URL — resource type, org, project, and ID are extracted automatically").optional(),
+        org_id: z.string().describe("Organization identifier (overrides default)").optional(),
+        project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        options: z.record(z.string(), z.unknown()).describe("Resource-specific diagnostic options. Pipeline: execution_id, pipeline_id, summary, include_yaml, include_logs, log_snippet_lines, max_failed_steps. GitOps: agent_id. Call harness_describe for details.").optional(),
+      },
+      annotations: {
+        title: "Diagnose Harness Resource",
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
     },
     async (args, extra) => {
       try {

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -11,19 +11,28 @@ import { applyUrlDefaults } from "../utils/url-parser.js";
 const log = createLogger("execute");
 
 export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient): void {
-  server.tool(
+  server.registerTool(
     "harness_execute",
-    "Execute an action on a Harness resource: run/retry/interrupt pipelines, toggle feature flags, test connectors, sync GitOps apps, run chaos experiments. You can pass a Harness URL to auto-extract identifiers.",
     {
-      resource_type: z.string().describe("The resource type (e.g. pipeline, execution, feature_flag, connector, gitops_application, chaos_experiment). Auto-detected from url if provided.").optional(),
-      url: z.string().describe("A Harness UI URL — org, project, resource type, and ID are extracted automatically").optional(),
-      action: z.string().describe("The action to execute (e.g. run, retry, interrupt, toggle, test_connection, sync)"),
-      resource_id: z.string().describe("The primary identifier of the resource").optional(),
-      org_id: z.string().describe("Organization identifier (overrides default)").optional(),
-      project_id: z.string().describe("Project identifier (overrides default)").optional(),
-      inputs: z.record(z.string(), z.unknown()).describe("Runtime inputs for pipeline execution").optional(),
-      body: z.record(z.string(), z.unknown()).describe("Additional body payload for the action").optional(),
-      params: z.record(z.string(), z.unknown()).describe("Action-specific parameters (e.g. pipeline_id, execution_id, flag_id, agent_id, interrupt_type, enable, environment, module). Call harness_describe for available actions and fields per resource_type.").optional(),
+      description: "Execute an action on a Harness resource: run/retry/interrupt pipelines, toggle feature flags, test connectors, sync GitOps apps, run chaos experiments. You can pass a Harness URL to auto-extract identifiers.",
+      inputSchema: {
+        resource_type: z.string().describe("The resource type (e.g. pipeline, execution, feature_flag, connector, gitops_application, chaos_experiment). Auto-detected from url if provided.").optional(),
+        url: z.string().describe("A Harness UI URL — org, project, resource type, and ID are extracted automatically").optional(),
+        action: z.string().describe("The action to execute (e.g. run, retry, interrupt, toggle, test_connection, sync)"),
+        resource_id: z.string().describe("The primary identifier of the resource").optional(),
+        org_id: z.string().describe("Organization identifier (overrides default)").optional(),
+        project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        inputs: z.record(z.string(), z.unknown()).describe("Runtime inputs for pipeline execution").optional(),
+        body: z.record(z.string(), z.unknown()).describe("Additional body payload for the action").optional(),
+        params: z.record(z.string(), z.unknown()).describe("Action-specific parameters (e.g. pipeline_id, execution_id, flag_id, agent_id, interrupt_type, enable, environment, module). Call harness_describe for available actions and fields per resource_type.").optional(),
+      },
+      annotations: {
+        title: "Execute Harness Action",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
     async (args) => {
       try {

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -7,16 +7,23 @@ import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.
 import { applyUrlDefaults } from "../utils/url-parser.js";
 
 export function registerGetTool(server: McpServer, registry: Registry, client: HarnessClient): void {
-  server.tool(
+  server.registerTool(
     "harness_get",
-    "Get a specific Harness resource by ID. You can pass a Harness URL to auto-extract org, project, resource type, and resource ID. For troubleshooting failures or health issues, prefer harness_diagnose — it combines multiple API calls with domain-specific analysis. Call harness_describe to discover available resource_types and which support diagnosis.",
     {
-      resource_type: z.string().describe("The type of resource to get (e.g. pipeline, service, environment). Auto-detected from url if provided.").optional(),
-      resource_id: z.string().describe("The primary identifier of the resource. Auto-detected from url if provided.").optional(),
-      url: z.string().describe("A Harness UI URL — org, project, resource type, and ID are extracted automatically").optional(),
-      org_id: z.string().describe("Organization identifier (overrides default)").optional(),
-      project_id: z.string().describe("Project identifier (overrides default)").optional(),
-      params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources (e.g. pipeline_id, environment_id, agent_id, repo_id, version_label). Call harness_describe for required fields per resource_type.").optional(),
+      description: "Get a specific Harness resource by ID. You can pass a Harness URL to auto-extract org, project, resource type, and resource ID. For troubleshooting failures or health issues, prefer harness_diagnose — it combines multiple API calls with domain-specific analysis. Call harness_describe to discover available resource_types and which support diagnosis.",
+      inputSchema: {
+        resource_type: z.string().describe("The type of resource to get (e.g. pipeline, service, environment). Auto-detected from url if provided.").optional(),
+        resource_id: z.string().describe("The primary identifier of the resource. Auto-detected from url if provided.").optional(),
+        url: z.string().describe("A Harness UI URL — org, project, resource type, and ID are extracted automatically").optional(),
+        org_id: z.string().describe("Organization identifier (overrides default)").optional(),
+        project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources (e.g. pipeline_id, environment_id, agent_id, repo_id, version_label). Call harness_describe for required fields per resource_type.").optional(),
+      },
+      annotations: {
+        title: "Get Harness Resource",
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
     },
     async (args) => {
       try {

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -8,19 +8,26 @@ import { compactItems } from "../utils/compact.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 
 export function registerListTool(server: McpServer, registry: Registry, client: HarnessClient): void {
-  server.tool(
+  server.registerTool(
     "harness_list",
-    "List Harness resources by type with filtering and pagination. You can pass a Harness URL to auto-extract org, project, and resource type. Call harness_describe to discover available resource_types.",
     {
-      resource_type: z.string().describe("The type of resource to list (e.g. pipeline, service, environment, connector). Auto-detected from url if provided.").optional(),
-      url: z.string().describe("A Harness UI URL — org, project, and resource type are extracted automatically").optional(),
-      org_id: z.string().describe("Organization identifier (overrides default)").optional(),
-      project_id: z.string().describe("Project identifier (overrides default)").optional(),
-      page: z.number().describe("Page number, 0-indexed").default(0).optional(),
-      size: z.number().min(1).max(100).describe("Page size (1–100)").default(20).optional(),
-      search_term: z.string().describe("Filter results by name or keyword").optional(),
-      compact: z.boolean().describe("Strip verbose metadata from list items, keeping only essential fields (default true)").default(true).optional(),
-      filters: z.record(z.string(), z.unknown()).describe("Additional filter fields passed to the API (e.g. status, module, pipeline_id, environment_id, agent_id). Call harness_describe for available filters per resource_type.").optional(),
+      description: "List Harness resources by type with filtering and pagination. You can pass a Harness URL to auto-extract org, project, and resource type. Call harness_describe to discover available resource_types.",
+      inputSchema: {
+        resource_type: z.string().describe("The type of resource to list (e.g. pipeline, service, environment, connector). Auto-detected from url if provided.").optional(),
+        url: z.string().describe("A Harness UI URL — org, project, and resource type are extracted automatically").optional(),
+        org_id: z.string().describe("Organization identifier (overrides default)").optional(),
+        project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        page: z.number().describe("Page number, 0-indexed").default(0).optional(),
+        size: z.number().min(1).max(100).describe("Page size (1–100)").default(20).optional(),
+        search_term: z.string().describe("Filter results by name or keyword").optional(),
+        compact: z.boolean().describe("Strip verbose metadata from list items, keeping only essential fields (default true)").default(true).optional(),
+        filters: z.record(z.string(), z.unknown()).describe("Additional filter fields passed to the API (e.g. status, module, pipeline_id, environment_id, agent_id). Call harness_describe for available filters per resource_type.").optional(),
+      },
+      annotations: {
+        title: "List Harness Resources",
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
     },
     async (args) => {
       try {

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -33,17 +33,24 @@ interface SearchResultEntry {
 }
 
 export function registerSearchTool(server: McpServer, registry: Registry, client: HarnessClient): void {
-  server.tool(
+  server.registerTool(
     "harness_search",
-    "Search across multiple Harness resource types simultaneously. Returns results ranked by relevance (pipelines/services first, then templates/triggers, then others). You can pass a Harness URL to auto-extract org and project.",
     {
-      query: z.string().describe("Search term to find across resource types"),
-      resource_types: z.array(z.string()).describe("Resource types to search (defaults to all listable types if empty)").optional(),
-      url: z.string().describe("A Harness UI URL — org and project are extracted automatically").optional(),
-      org_id: z.string().describe("Organization identifier (overrides default)").optional(),
-      project_id: z.string().describe("Project identifier (overrides default)").optional(),
-      max_per_type: z.number().describe("Max results per resource type").default(5).optional(),
-      compact: z.boolean().describe("Strip verbose metadata from results (default true)").default(true).optional(),
+      description: "Search across multiple Harness resource types simultaneously. Returns results ranked by relevance (pipelines/services first, then templates/triggers, then others). You can pass a Harness URL to auto-extract org and project.",
+      inputSchema: {
+        query: z.string().describe("Search term to find across resource types"),
+        resource_types: z.array(z.string()).describe("Resource types to search (defaults to all listable types if empty)").optional(),
+        url: z.string().describe("A Harness UI URL — org and project are extracted automatically").optional(),
+        org_id: z.string().describe("Organization identifier (overrides default)").optional(),
+        project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        max_per_type: z.number().describe("Max results per resource type").default(5).optional(),
+        compact: z.boolean().describe("Strip verbose metadata from results (default true)").default(true).optional(),
+      },
+      annotations: {
+        title: "Search Harness Resources",
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
     },
     async (args, extra) => {
       try {

--- a/src/tools/harness-status.ts
+++ b/src/tools/harness-status.ts
@@ -69,14 +69,21 @@ export function registerStatusTool(
   client: HarnessClient,
   config: Config,
 ): void {
-  server.tool(
+  server.registerTool(
     "harness_status",
-    "Get a live project health overview: recent failed executions, currently running executions, and recent deployment activity. You can pass a Harness URL to auto-extract org and project. Ideal first question: 'what's happening in my project right now?'",
     {
-      org_id: z.string().describe("Organization identifier (overrides default)").optional(),
-      project_id: z.string().describe("Project identifier (overrides default)").optional(),
-      url: z.string().describe("A Harness UI URL — org and project are extracted automatically").optional(),
-      limit: z.number().describe("Max items per section (default 5, max 20)").default(5).optional(),
+      description: "Get a live project health overview: recent failed executions, currently running executions, and recent deployment activity. You can pass a Harness URL to auto-extract org and project. Ideal first question: 'what's happening in my project right now?'",
+      inputSchema: {
+        org_id: z.string().describe("Organization identifier (overrides default)").optional(),
+        project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        url: z.string().describe("A Harness UI URL — org and project are extracted automatically").optional(),
+        limit: z.number().describe("Max items per section (default 5, max 20)").default(5).optional(),
+      },
+      annotations: {
+        title: "Project Health Status",
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
     },
     async (args, extra) => {
       try {

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -8,17 +8,26 @@ import { confirmViaElicitation } from "../utils/elicitation.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 
 export function registerUpdateTool(server: McpServer, registry: Registry, client: HarnessClient): void {
-  server.tool(
+  server.registerTool(
     "harness_update",
-    "Update an existing Harness resource. You can pass a Harness URL to auto-extract identifiers. Response includes openInHarness link to the updated resource when applicable.",
     {
-      resource_type: z.string().describe("The type of resource to update (e.g. pipeline, service, environment, connector, trigger)"),
-      resource_id: z.string().describe("The identifier of the resource to update"),
-      url: z.string().describe("A Harness UI URL — org, project, resource type, and ID are extracted automatically").optional(),
-      body: z.record(z.string(), z.unknown()).describe("The updated resource definition body"),
-      org_id: z.string().describe("Organization identifier (overrides default)").optional(),
-      project_id: z.string().describe("Project identifier (overrides default)").optional(),
-      params: z.record(z.string(), z.unknown()).describe("Additional identifiers (e.g. pipeline_id for triggers, version_label for templates).").optional(),
+      description: "Update an existing Harness resource. You can pass a Harness URL to auto-extract identifiers. Response includes openInHarness link to the updated resource when applicable.",
+      inputSchema: {
+        resource_type: z.string().describe("The type of resource to update (e.g. pipeline, service, environment, connector, trigger)"),
+        resource_id: z.string().describe("The identifier of the resource to update"),
+        url: z.string().describe("A Harness UI URL — org, project, resource type, and ID are extracted automatically").optional(),
+        body: z.record(z.string(), z.unknown()).describe("The updated resource definition body"),
+        org_id: z.string().describe("Organization identifier (overrides default)").optional(),
+        project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        params: z.record(z.string(), z.unknown()).describe("Additional identifiers (e.g. pipeline_id for triggers, version_label for templates).").optional(),
+      },
+      annotations: {
+        title: "Update Harness Resource",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
     },
     async (args) => {
       try {

--- a/stderr.log
+++ b/stderr.log
@@ -1,0 +1,8 @@
+Fatal error: Error: Invalid configuration:
+  HARNESS_API_KEY: Required
+    at loadConfig (file:///Users/rohangupta/code/harness-poc-mcp/build/config.js:31:15)
+    at main (file:///Users/rohangupta/code/harness-poc-mcp/build/index.js:118:20)
+    at file:///Users/rohangupta/code/harness-poc-mcp/build/index.js:136:1
+    at ModuleJob.run (node:internal/modules/esm/module_job:377:25)
+    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:671:26)
+    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)

--- a/tests/tools/diagnose/router.test.ts
+++ b/tests/tools/diagnose/router.test.ts
@@ -15,7 +15,7 @@ let registry: Registry;
 
 function mockServer(): McpServer {
   return {
-    tool: vi.fn((_name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+    registerTool: vi.fn((_name: string, _config: unknown, handler: ToolHandler) => {
       capturedHandler = handler;
     }),
   } as unknown as McpServer;


### PR DESCRIPTION
## Summary
- Migrate all 10 tools from deprecated `server.tool()` to `server.registerTool()` with proper `annotations`
- Migrate all 26 prompts from deprecated `server.prompt()` to `server.registerPrompt()`
- Resources already used `registerResource()` — no changes needed
- Safety-aware clients can now distinguish read vs write operations without prompting on every call

## Tool annotations

| Tool | readOnlyHint | destructiveHint | idempotentHint | openWorldHint |
|------|-------------|-----------------|----------------|---------------|
| harness_describe | true | — | — | false |
| harness_list | true | — | — | true |
| harness_get | true | — | — | true |
| harness_search | true | — | — | true |
| harness_status | true | — | — | true |
| harness_diagnose | true | — | — | true |
| harness_create | false | false | false | true |
| harness_update | false | false | true | true |
| harness_execute | false | false | false | true |
| harness_delete | false | **true** | true | true |

## Changed files
- 10 tool files: all migrated to `registerTool()` with annotations
- 26 prompt files: all migrated to `registerPrompt()`
- 1 test file: updated mock to use `registerTool` instead of `tool`

## Test plan
- [x] All 223 tests pass
- [x] Clean `tsc` build
- [x] Zero `server.tool()` or `server.prompt()` calls remaining in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)