### PR TITLE
fix: evict expired rate-limit entries to prevent memory leak

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,13 +136,19 @@ async function startHttp(config: Config, port: number): Promise<void> {
     log.info("Session destroyed", { sessionId, remaining: sessions.size });
   }
 
-  // TTL reaper — evicts idle sessions
+  // TTL reaper — evicts idle sessions and expired rate-limit entries
   const reaper = setInterval(() => {
     const now = Date.now();
     for (const [id, session] of sessions) {
       if (now - session.lastActivity > SESSION_TTL_MS) {
         log.info("Reaping idle session", { sessionId: id });
         destroySession(id);
+      }
+    }
+    // Evict expired rate-limit entries to prevent unbounded map growth
+    for (const [ip, entry] of ipHits) {
+      if (now >= entry.resetAt) {
+        ipHits.delete(ip);
       }
     }
   }, REAP_INTERVAL_MS);


### PR DESCRIPTION
## Summary
The `ipHits` map in HTTP mode grows indefinitely — expired entries are replaced on access but never removed for IPs that stop sending requests.

Fix: piggyback on the existing session TTL reaper (runs every 60s) to sweep expired rate-limit entries.

## What changed (`src/index.ts`, +7/-1)
Added 5 lines to the existing reaper interval to delete `ipHits` entries where `now >= entry.resetAt`.

## Test plan
- [x] All 225 tests pass
- [x] Clean `tsc` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)