### PR TITLE
fix: validate HARNESS_TOOLSETS against known toolset names

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -87,7 +87,30 @@ export class Registry {
   private parseToolsetFilter(): Set<ToolsetName> | null {
     const raw = this.config.HARNESS_TOOLSETS;
     if (!raw || raw.trim() === "") return null;
-    return new Set(raw.split(",").map((s) => s.trim()) as ToolsetName[]);
+
+    const validNames = new Set<string>(ALL_TOOLSETS.map((t) => t.name));
+    const parsed = raw.split(",").map((s) => s.trim()).filter(Boolean);
+    const valid: ToolsetName[] = [];
+    const invalid: string[] = [];
+
+    for (const name of parsed) {
+      if (validNames.has(name)) {
+        valid.push(name as ToolsetName);
+      } else {
+        invalid.push(name);
+      }
+    }
+
+    if (invalid.length > 0) {
+      const available = Array.from(validNames).sort().join(", ");
+      throw new Error(
+        `Invalid HARNESS_TOOLSETS: ${invalid.map((n) => `"${n}"`).join(", ")}. ` +
+        `Valid toolset names: ${available}`,
+      );
+    }
+
+    if (valid.length === 0) return null;
+    return new Set(valid);
   }
 
   /** Get a resource definition by type, or throw. */

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -40,10 +40,32 @@ describe("Registry", () => {
       expect(desc.total_toolsets).toBe(2);
     });
 
-    it("loads zero toolsets for non-matching filter", () => {
-      const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "nonexistent" }));
+    it("throws for invalid toolset names in HARNESS_TOOLSETS", () => {
+      expect(() => new Registry(makeConfig({ HARNESS_TOOLSETS: "nonexistent" }))).toThrow(
+        /Invalid HARNESS_TOOLSETS: "nonexistent"/,
+      );
+    });
+
+    it("throws for typo in toolset name (e.g. 'pipeline' instead of 'pipelines')", () => {
+      expect(() => new Registry(makeConfig({ HARNESS_TOOLSETS: "pipeline" }))).toThrow(
+        /Invalid HARNESS_TOOLSETS: "pipeline"/,
+      );
+      expect(() => new Registry(makeConfig({ HARNESS_TOOLSETS: "pipeline" }))).toThrow(
+        /Valid toolset names:/,
+      );
+    });
+
+    it("throws listing all invalid names when multiple are wrong", () => {
+      expect(() => new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines,badname,services,oops" }))).toThrow(
+        /Invalid HARNESS_TOOLSETS: "badname", "oops"/,
+      );
+    });
+
+    it("accepts all valid toolset names without error", () => {
+      // Just use a few known-good names
+      const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines,services,connectors" }));
       const desc = registry.describe() as { total_toolsets: number };
-      expect(desc.total_toolsets).toBe(0);
+      expect(desc.total_toolsets).toBe(3);
     });
   });
 


### PR DESCRIPTION
## Summary
- `HARNESS_TOOLSETS` was unsafely cast to `ToolsetName[]` — typos like `"pipeline"` (missing `s`) silently dropped the toolset with no error
- `parseToolsetFilter()` now validates each name against `ALL_TOOLSETS` and throws a clear error listing invalid names and all valid options
- Added 4 tests covering: invalid names, typo detection, multiple invalid names, and valid names acceptance

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 228 tests pass (`npx vitest run`)
- [x] Manual: set `HARNESS_TOOLSETS=pipeline` (typo) and verify server fails to start with descriptive error

🤖 Generated with [Claude Code](https://claude.com/claude-code)