### PR TITLE
fix: thread AbortSignal cancellation through to HTTP client

### DIFF
--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -59,8 +59,17 @@ export class HarnessClient {
       }
 
       try {
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), this.timeout);
+        // Check if already aborted before starting the request
+        if (options.signal?.aborted) {
+          throw options.signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+        }
+
+        const timeoutController = new AbortController();
+        const timer = setTimeout(() => timeoutController.abort(), this.timeout);
+        // Merge external signal (client disconnect) with timeout signal
+        const signal = options.signal
+          ? AbortSignal.any([options.signal, timeoutController.signal])
+          : timeoutController.signal;
 
         log.debug(`${method} ${url}`);
 
@@ -70,7 +79,7 @@ export class HarnessClient {
           body: options.body
             ? (typeof options.body === "string" ? options.body : JSON.stringify(options.body))
             : undefined,
-          signal: controller.signal,
+          signal,
         });
 
         clearTimeout(timer);
@@ -104,6 +113,11 @@ export class HarnessClient {
       } catch (err) {
         if (err instanceof HarnessApiError) throw err;
         if (err instanceof Error && err.name === "AbortError") {
+          // External signal (client disconnect) — stop immediately, don't retry
+          if (options.signal?.aborted) {
+            throw new HarnessApiError("Request cancelled", 499);
+          }
+          // Timeout — retry if allowed
           lastError = new HarnessApiError("Request timed out", 408);
           if (attempt < this.maxRetries) continue;
           throw lastError;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -45,4 +45,6 @@ export interface RequestOptions {
   headers?: Record<string, string>;
   /** Override base path prefix (e.g. "/pipeline/api" vs "/ng/api") */
   rawPath?: boolean;
+  /** External abort signal (e.g. from MCP client disconnect). Merged with timeout. */
+  signal?: AbortSignal;
 }

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -153,6 +153,7 @@ export class Registry {
     resourceType: string,
     operation: OperationName,
     input: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<unknown> {
     if (this.config.HARNESS_READ_ONLY && !Registry.READ_OPERATIONS.has(operation)) {
       throw new Error(`Read-only mode is enabled (HARNESS_READ_ONLY=true). "${operation}" operations are not allowed.`);
@@ -165,7 +166,7 @@ export class Registry {
       throw new Error(`Resource "${resourceType}" does not support "${operation}". Supported: ${supported}`);
     }
 
-    return this.executeSpec(client, def, spec, input);
+    return this.executeSpec(client, def, spec, input, signal);
   }
 
   /** Dispatch an execute action to the Harness API. */
@@ -174,6 +175,7 @@ export class Registry {
     resourceType: string,
     action: string,
     input: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<unknown> {
     if (this.config.HARNESS_READ_ONLY) {
       throw new Error(`Read-only mode is enabled (HARNESS_READ_ONLY=true). Execute actions are not allowed.`);
@@ -186,7 +188,7 @@ export class Registry {
       throw new Error(`Resource "${resourceType}" has no execute action "${action}". Available: ${available}`);
     }
 
-    return this.executeSpec(client, def, actionSpec, input);
+    return this.executeSpec(client, def, actionSpec, input, signal);
   }
 
   private async executeSpec(
@@ -194,6 +196,7 @@ export class Registry {
     def: ResourceDefinition,
     spec: EndpointSpec,
     input: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<unknown> {
     // Build path with substitutions
     let path = spec.path;
@@ -259,6 +262,7 @@ export class Registry {
       params,
       body,
       ...(spec.headers ? { headers: spec.headers } : {}),
+      signal,
     });
 
     // Extract response

--- a/src/tools/diagnose/connector.ts
+++ b/src/tools/diagnose/connector.ts
@@ -9,7 +9,7 @@ export const connectorHandler: DiagnoseHandler = {
   description: "Diagnose a connector — fetches details and runs a connectivity test, returning type, auth method, status, and any connection errors.",
 
   async diagnose(ctx: DiagnoseContext): Promise<Record<string, unknown>> {
-    const { client, registry, config, input, extra } = ctx;
+    const { client, registry, config, input, extra, signal } = ctx;
 
     const connectorId = (input.resource_id as string) ?? (input.connector_id as string);
     if (!connectorId) {
@@ -23,7 +23,7 @@ export const connectorHandler: DiagnoseHandler = {
     await sendProgress(extra, 0, 2, "Fetching connector details...");
     log.info("Fetching connector", { connectorId });
 
-    const raw = await registry.dispatch(client, "connector", "get", input);
+    const raw = await registry.dispatch(client, "connector", "get", input, signal);
     const connectorData = raw as Record<string, unknown>;
     const connector = (connectorData.connector ?? connectorData) as Record<string, unknown>;
     const spec = connector.spec as Record<string, unknown> | undefined;
@@ -77,7 +77,7 @@ export const connectorHandler: DiagnoseHandler = {
     log.info("Testing connector connectivity", { connectorId });
 
     try {
-      const testResult = await registry.dispatchExecute(client, "connector", "test_connection", input);
+      const testResult = await registry.dispatchExecute(client, "connector", "test_connection", input, signal);
       const test = testResult as Record<string, unknown>;
 
       diagnostic.test_result = {

--- a/src/tools/diagnose/delegate.ts
+++ b/src/tools/diagnose/delegate.ts
@@ -84,7 +84,7 @@ export const delegateHandler: DiagnoseHandler = {
   description: "Diagnose delegate health — lists all delegates, reports connectivity, heartbeat status, version, and any detected issues.",
 
   async diagnose(ctx: DiagnoseContext): Promise<Record<string, unknown>> {
-    const { client, registry, config, input, extra } = ctx;
+    const { client, registry, config, input, extra, signal } = ctx;
 
     const targetId = (input.resource_id as string) ?? (input.delegate_id as string);
 
@@ -92,7 +92,7 @@ export const delegateHandler: DiagnoseHandler = {
     log.info("Listing delegates", { targetId: targetId ?? "all" });
 
     // Always pass all=true to get delegates across all org/project scopes
-    const raw = await registry.dispatch(client, "delegate", "list", { ...input, all: "true" });
+    const raw = await registry.dispatch(client, "delegate", "list", { ...input, all: "true" }, signal);
 
     let delegates: DelegateInfo[];
     if (Array.isArray(raw)) {

--- a/src/tools/diagnose/gitops-application.ts
+++ b/src/tools/diagnose/gitops-application.ts
@@ -153,7 +153,7 @@ export const gitopsApplicationHandler: DiagnoseHandler = {
   description: "Diagnose a GitOps application — combines app sync/health status, Kubernetes resource tree health, and recent warning events into a single diagnosis.",
 
   async diagnose(ctx: DiagnoseContext): Promise<Record<string, unknown>> {
-    const { client, registry, config, input, extra } = ctx;
+    const { client, registry, config, input, extra, signal } = ctx;
 
     const agentId = input.agent_id as string | undefined;
     const appName = (input.resource_id as string) ?? (input.app_name as string);
@@ -174,9 +174,9 @@ export const gitopsApplicationHandler: DiagnoseHandler = {
     log.info("Diagnosing GitOps application", { agentId, appName });
 
     const [appResult, treeResult, eventsResult] = await Promise.allSettled([
-      registry.dispatch(client, "gitops_application", "get", dispatchInput),
-      registry.dispatch(client, "gitops_app_resource_tree", "get", dispatchInput),
-      registry.dispatch(client, "gitops_app_event", "list", dispatchInput),
+      registry.dispatch(client, "gitops_application", "get", dispatchInput, signal),
+      registry.dispatch(client, "gitops_app_resource_tree", "get", dispatchInput, signal),
+      registry.dispatch(client, "gitops_app_event", "list", dispatchInput, signal),
     ]);
 
     // 1. App status (required)

--- a/src/tools/diagnose/pipeline.ts
+++ b/src/tools/diagnose/pipeline.ts
@@ -282,6 +282,7 @@ function findChildPipelineRef(
 async function diagnoseChildPipeline(
   client: HarnessClient,
   child: { executionId: string; orgId: string; projectId: string },
+  signal?: AbortSignal,
 ): Promise<FailedNodeDetail[]> {
   try {
     const response = await client.request<Record<string, unknown>>({
@@ -292,6 +293,7 @@ async function diagnoseChildPipeline(
         projectIdentifier: child.projectId,
         renderFullBottomGraph: "true",
       },
+      signal,
     });
     const data = (response as Record<string, unknown>).data ?? response;
     const execGraph = (data as Record<string, unknown>).executionGraph as Record<string, unknown> | undefined;
@@ -441,7 +443,7 @@ export const pipelineHandler: DiagnoseHandler = {
   description: "Analyze a pipeline execution — stage/step breakdown, timing, bottlenecks, failure details with exact step, error, delegate, and script context.",
 
   async diagnose(ctx: DiagnoseContext): Promise<Record<string, unknown>> {
-    const { client, registry, config, input, args, extra } = ctx;
+    const { client, registry, config, input, args, extra, signal } = ctx;
 
     let executionId = input.execution_id as string | undefined;
     const pipelineId = input.pipeline_id as string | undefined;
@@ -465,7 +467,7 @@ export const pipelineHandler: DiagnoseHandler = {
           pipeline_id: pipelineId,
           size: 1,
           page: 0,
-        });
+        }, signal);
         const items = (execList as { items?: Array<Record<string, unknown>> }).items;
         if (items && items.length > 0) {
           executionId = (items[0].planExecutionId as string) ?? undefined;
@@ -491,7 +493,7 @@ export const pipelineHandler: DiagnoseHandler = {
       const execution = await registry.dispatch(client, "execution", "get", {
         ...input,
         render_full_graph: true,
-      });
+      }, signal);
 
       const exec = execution as Record<string, unknown>;
       const pes = exec?.pipelineExecutionSummary as Record<string, unknown> | undefined;
@@ -504,7 +506,7 @@ export const pipelineHandler: DiagnoseHandler = {
 
         if (result.childRef) {
           log.info("Detected chained pipeline failure, diagnosing child", result.childRef);
-          const childFailedNodes = await diagnoseChildPipeline(client, result.childRef);
+          const childFailedNodes = await diagnoseChildPipeline(client, result.childRef, signal);
           if (childFailedNodes.length > 0) {
             const childEntry = (f: FailedNodeDetail) => {
               const e: Record<string, unknown> = {
@@ -543,7 +545,7 @@ export const pipelineHandler: DiagnoseHandler = {
           const pipeline = await registry.dispatch(client, "pipeline", "get", {
             ...input,
             pipeline_id: resolvedPipelineId,
-          });
+          }, signal);
           diagnostic.pipeline = pipeline;
         } catch (err) {
           log.warn("Failed to fetch pipeline YAML", { error: String(err) });
@@ -572,7 +574,7 @@ export const pipelineHandler: DiagnoseHandler = {
             const logData = await registry.dispatch(client, "execution_log", "get", {
               ...input,
               prefix,
-            });
+            }, signal);
             return { key, value: truncateLog(logData, logSnippetLines) };
           } catch (err) {
             log.warn("Failed to fetch step logs", { step: fn.step, error: String(err) });

--- a/src/tools/diagnose/types.ts
+++ b/src/tools/diagnose/types.ts
@@ -13,6 +13,7 @@ export interface DiagnoseContext {
   input: Record<string, unknown>;
   args: Record<string, unknown>;
   extra: Extra;
+  signal: AbortSignal;
 }
 
 export interface DiagnoseHandler {

--- a/src/tools/harness-diagnose.ts
+++ b/src/tools/harness-diagnose.ts
@@ -66,7 +66,7 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
           );
         }
 
-        const ctx: DiagnoseContext = { client, registry, config, input, args: mergedArgs, extra };
+        const ctx: DiagnoseContext = { client, registry, config, input, args: mergedArgs, extra, signal: extra.signal };
         const result = await handler.diagnose(ctx);
         return jsonResult(result);
       } catch (err) {

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -54,6 +54,7 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
     },
     async (args, extra) => {
       try {
+        const signal = extra.signal;
         const mergedArgs = applyUrlDefaults(args as Record<string, unknown>, args.url);
         // Determine which resource types to search
         let targetTypes = args.resource_types ?? [];
@@ -71,6 +72,8 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
         let searched = 0;
 
         for (let i = 0; i < targetTypes.length; i += MAX_CONCURRENCY) {
+          // Check for cancellation between batches
+          signal.throwIfAborted();
           const batch = targetTypes.slice(i, i + MAX_CONCURRENCY);
           await sendProgress(extra, searched, targetTypes.length, `Searching batch ${Math.floor(i / MAX_CONCURRENCY) + 1}...`);
           const batchResults = await Promise.all(
@@ -85,7 +88,7 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
                   size: args.max_per_type ?? 5,
                   limit: args.max_per_type ?? 5,
                   page: 0,
-                });
+                }, signal);
                 return { rt, result, error: null };
               } catch (err) {
                 log.debug(`Search failed for ${rt}`, { error: String(err) });

--- a/src/tools/harness-status.ts
+++ b/src/tools/harness-status.ts
@@ -87,6 +87,7 @@ export function registerStatusTool(
     },
     async (args, extra) => {
       try {
+        const signal = extra.signal;
         const merged = applyUrlDefaults(args as Record<string, unknown>, args.url);
         const orgId = (merged.org_id as string) ?? config.HARNESS_DEFAULT_ORG_ID;
         const projectId = (merged.project_id as string) ?? config.HARNESS_DEFAULT_PROJECT_ID ?? "";
@@ -107,15 +108,15 @@ export function registerStatusTool(
           registry.dispatch(client, "execution", "list", {
             ...baseInput,
             status: "Failed",
-          }),
+          }, signal),
           registry.dispatch(client, "execution", "list", {
             ...baseInput,
             status: "Running",
-          }),
+          }, signal),
           registry.dispatch(client, "execution", "list", {
             ...baseInput,
             size: Math.min(limit * 2, 20),
-          }),
+          }, signal),
         ]);
 
         // Extract results with graceful degradation

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -255,6 +255,61 @@ describe("HarnessClient", () => {
     });
   });
 
+  describe("request — abort signal", () => {
+    it("throws 499 immediately when signal is already aborted", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ data: "ok" }), { status: 200 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+      const controller = new AbortController();
+      controller.abort();
+
+      try {
+        await client.request({ path: "/test", signal: controller.signal });
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HarnessApiError);
+        expect((err as HarnessApiError).statusCode).toBe(499);
+        expect((err as HarnessApiError).message).toContain("cancelled");
+      }
+      // fetch should NOT have been called
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("throws 499 when signal aborts during request (no retry)", async () => {
+      const controller = new AbortController();
+      fetchSpy.mockImplementation(() => {
+        // Abort mid-request
+        controller.abort();
+        const err = new Error("The operation was aborted");
+        err.name = "AbortError";
+        return Promise.reject(err);
+      });
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 3 }));
+
+      try {
+        await client.request({ path: "/test", signal: controller.signal });
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HarnessApiError);
+        expect((err as HarnessApiError).statusCode).toBe(499);
+        expect((err as HarnessApiError).message).toContain("cancelled");
+      }
+      // Should NOT retry — only 1 call
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes signal through to fetch", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ data: "ok" }), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+      const controller = new AbortController();
+
+      await client.request({ path: "/test", signal: controller.signal });
+
+      // The signal passed to fetch should be a combined signal (AbortSignal.any)
+      const fetchOptions = fetchSpy.mock.calls[0][1] as RequestInit;
+      expect(fetchOptions.signal).toBeDefined();
+    });
+  });
+
   describe("request — body serialization", () => {
     it("sends JSON-stringified body for objects", async () => {
       fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));


### PR DESCRIPTION
## Summary
- Long-running tools (search, diagnose, status) now thread `extra.signal` from the MCP SDK through `registry.dispatch()` to `HarnessClient.request()`, so disconnected clients stop wasting Harness API calls
- `HarnessClient.request()` merges the external signal with its timeout controller via `AbortSignal.any()` — cancellation throws HTTP 499 immediately with no retry, while timeouts still retry as before (408)
- Signal threaded through all 4 layers: `RequestOptions.signal` → `HarnessClient.request()` → `Registry.dispatch()/dispatchExecute()/executeSpec()` → tool handlers + all 4 diagnose sub-handlers (pipeline, connector, delegate, gitops-application)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 231 tests pass (3 new abort signal tests)
- [x] Test: pre-aborted signal throws 499 without calling fetch
- [x] Test: mid-request abort throws 499 with no retry (single fetch call)
- [x] Test: signal is forwarded to fetch options
- [ ] Manual: run search tool, disconnect client mid-request, verify API calls stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)