### PR TITLE
fix: guard response.json() against non-JSON and empty responses

### DIFF
--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -108,7 +108,22 @@ export class HarnessClient {
           throw error;
         }
 
-        const data = await response.json();
+        const text = await response.text();
+        if (!text) {
+          throw new HarnessApiError(
+            `Empty response body from ${method} ${options.path}`,
+            502,
+          );
+        }
+        let data: unknown;
+        try {
+          data = JSON.parse(text);
+        } catch {
+          throw new HarnessApiError(
+            `Non-JSON response from ${method} ${options.path}: ${text.slice(0, 200)}`,
+            502,
+          );
+        }
         return data as T;
       } catch (err) {
         if (err instanceof HarnessApiError) throw err;

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -310,6 +310,46 @@ describe("HarnessClient", () => {
     });
   });
 
+  describe("request — non-JSON responses", () => {
+    it("throws clear error for HTML response (proxy error page)", async () => {
+      const html = "<html><body><h1>502 Bad Gateway</h1></body></html>";
+      fetchSpy.mockResolvedValue(new Response(html, { status: 200, headers: { "Content-Type": "text/html" } }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      try {
+        await client.request({ path: "/test" });
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HarnessApiError);
+        expect((err as HarnessApiError).statusCode).toBe(502);
+        expect((err as HarnessApiError).message).toContain("Non-JSON response");
+        expect((err as HarnessApiError).message).toContain("502 Bad Gateway");
+      }
+    });
+
+    it("throws clear error for empty response body", async () => {
+      fetchSpy.mockResolvedValue(new Response("", { status: 200 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      try {
+        await client.request({ path: "/test" });
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HarnessApiError);
+        expect((err as HarnessApiError).statusCode).toBe(502);
+        expect((err as HarnessApiError).message).toContain("Empty response body");
+      }
+    });
+
+    it("parses valid JSON response normally", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ data: "ok" }), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      const result = await client.request<{ data: string }>({ path: "/test" });
+      expect(result.data).toBe("ok");
+    });
+  });
+
   describe("request — body serialization", () => {
     it("sends JSON-stringified body for objects", async () => {
       fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));


### PR DESCRIPTION
## Summary
- `response.json()` on 2xx responses was unguarded — proxy HTML error pages or empty bodies threw an untyped `SyntaxError` caught as a confusing generic 502
- Now reads `response.text()` first, then:
  - Empty body → `HarnessApiError("Empty response body from GET /path", 502)`
  - Non-JSON (HTML, plain text) → `HarnessApiError("Non-JSON response from GET /path: <first 200 chars>", 502)`
- Error messages now include the HTTP method and path for easier debugging

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 243 tests pass (3 new: HTML response, empty body, valid JSON)
- [x] Manual: point `HARNESS_BASE_URL` at a non-Harness URL and verify clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)