### PR TITLE
fix: preserve Error.cause chain in HarnessApiError

### DIFF
--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -118,10 +118,13 @@ export class HarnessClient {
         let data: unknown;
         try {
           data = JSON.parse(text);
-        } catch {
+        } catch (parseErr) {
           throw new HarnessApiError(
             `Non-JSON response from ${method} ${options.path}: ${text.slice(0, 200)}`,
             502,
+            undefined,
+            undefined,
+            parseErr,
           );
         }
         return data as T;
@@ -130,16 +133,19 @@ export class HarnessClient {
         if (err instanceof Error && err.name === "AbortError") {
           // External signal (client disconnect) — stop immediately, don't retry
           if (options.signal?.aborted) {
-            throw new HarnessApiError("Request cancelled", 499);
+            throw new HarnessApiError("Request cancelled", 499, undefined, undefined, err);
           }
           // Timeout — retry if allowed
-          lastError = new HarnessApiError("Request timed out", 408);
+          lastError = new HarnessApiError("Request timed out", 408, undefined, undefined, err);
           if (attempt < this.maxRetries) continue;
           throw lastError;
         }
         throw new HarnessApiError(
           `Request failed: ${(err as Error).message ?? String(err)}`,
           502,
+          undefined,
+          undefined,
+          err,
         );
       }
     }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -27,8 +27,9 @@ export class HarnessApiError extends Error {
     public readonly statusCode: number,
     public readonly harnessCode?: string,
     public readonly correlationId?: string,
+    cause?: unknown,
   ) {
-    super(message);
+    super(message, { cause });
     this.name = "HarnessApiError";
   }
 }
@@ -59,11 +60,15 @@ export function toMcpError(err: unknown): McpError {
   if (err instanceof HarnessApiError) {
     const code = mapHttpStatusToMcpCode(err.statusCode);
     const detail = err.correlationId ? ` (correlationId: ${err.correlationId})` : "";
-    return new McpError(code, `${err.message}${detail}`);
+    const mcpErr = new McpError(code, `${err.message}${detail}`);
+    mcpErr.cause = err;
+    return mcpErr;
   }
 
   if (err instanceof Error) {
-    return new McpError(ErrorCode.InternalError, err.message);
+    const mcpErr = new McpError(ErrorCode.InternalError, err.message);
+    mcpErr.cause = err;
+    return mcpErr;
   }
 
   return new McpError(ErrorCode.InternalError, String(err));

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -69,6 +69,46 @@ describe("isUserError", () => {
   });
 });
 
+describe("HarnessApiError — cause chain", () => {
+  it("preserves cause when provided", () => {
+    const original = new TypeError("fetch failed");
+    const err = new HarnessApiError("Request failed: fetch failed", 502, undefined, undefined, original);
+    expect(err.cause).toBe(original);
+  });
+
+  it("cause is undefined when not provided", () => {
+    const err = new HarnessApiError("Not found", 404);
+    expect(err.cause).toBeUndefined();
+  });
+
+  it("works with non-Error cause values", () => {
+    const err = new HarnessApiError("fail", 500, undefined, undefined, "raw string cause");
+    expect(err.cause).toBe("raw string cause");
+  });
+});
+
+describe("toMcpError — cause chain", () => {
+  it("preserves HarnessApiError as cause on McpError", () => {
+    const original = new HarnessApiError("timeout", 408);
+    const result = toMcpError(original);
+    expect(result.cause).toBe(original);
+  });
+
+  it("preserves plain Error as cause on McpError", () => {
+    const original = new Error("oops");
+    const result = toMcpError(original);
+    expect(result.cause).toBe(original);
+  });
+
+  it("preserves nested cause chain (HarnessApiError wrapping TypeError)", () => {
+    const root = new TypeError("network error");
+    const apiErr = new HarnessApiError("Request failed: network error", 502, undefined, undefined, root);
+    const mcpErr = toMcpError(apiErr);
+    expect(mcpErr.cause).toBe(apiErr);
+    expect((mcpErr.cause as HarnessApiError).cause).toBe(root);
+  });
+});
+
 describe("toMcpError", () => {
   it("passes through McpError unchanged", () => {
     const err = new McpError(ErrorCode.InvalidParams, "bad");


### PR DESCRIPTION
## Summary
- **HarnessApiError** now accepts an optional `cause` parameter and passes it to `super(message, { cause })` using the ES2022 error cause standard
- All 4 error-wrapping sites in `harness-client.ts` (JSON parse failure, cancel abort, timeout abort, generic catch-all) now thread the original error as `cause`
- `toMcpError()` manually sets `.cause` on McpError instances since McpError's constructor doesn't support the options bag pattern

## Test plan
- [x] 6 new tests for cause chain preservation (HarnessApiError + toMcpError)
- [x] All 249 existing tests pass
- [x] Type-check passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)