### PR TITLE
fix: add readonly to HarnessClient and RateLimiter private properties

### DIFF
--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -10,12 +10,12 @@ const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
 const BASE_BACKOFF_MS = 1000;
 
 export class HarnessClient {
-  private baseUrl: string;
-  private token: string;
-  private accountId: string;
-  private timeout: number;
-  private maxRetries: number;
-  private rateLimiter: RateLimiter;
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly accountId: string;
+  private readonly timeout: number;
+  private readonly maxRetries: number;
+  private readonly rateLimiter: RateLimiter;
 
   constructor(config: Config) {
     this.baseUrl = config.HARNESS_BASE_URL.replace(/\/$/, "");

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -6,8 +6,8 @@ export class RateLimiter {
   private lastRefill: number;
 
   constructor(
-    private maxTokens: number = 10,
-    private refillRatePerMs: number = maxTokens / 1000,
+    private readonly maxTokens: number = 10,
+    private readonly refillRatePerMs: number = maxTokens / 1000,
   ) {
     this.tokens = maxTokens;
     this.lastRefill = Date.now();


### PR DESCRIPTION
## Summary
- Mark all 6 constructor-assigned private properties on `HarnessClient` as `readonly` (`baseUrl`, `token`, `accountId`, `timeout`, `maxRetries`, `rateLimiter`)
- Mark both constructor parameters on `RateLimiter` as `readonly` (`maxTokens`, `refillRatePerMs`)
- Prevents accidental mutation after construction

## Test plan
- [x] Type-check passes
- [x] All 249 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)