### PR TITLE
fix: enable noUncheckedIndexedAccess in tsconfig

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,8 +7,9 @@ import * as z from "zod/v4";
  */
 export function extractAccountIdFromToken(apiKey: string): string | undefined {
   const parts = apiKey.split(".");
-  if (parts.length >= 3 && parts[0] === "pat" && parts[1].length > 0) {
-    return parts[1];
+  const accountId = parts[1];
+  if (parts.length >= 3 && parts[0] === "pat" && accountId && accountId.length > 0) {
+    return accountId;
   }
   return undefined;
 }

--- a/src/resources/pipeline-yaml.ts
+++ b/src/resources/pipeline-yaml.ts
@@ -51,11 +51,11 @@ export function registerPipelineYamlResource(server: McpServer, registry: Regist
       let pipelineId: string;
 
       if (parts.length >= 3) {
-        orgId = parts[0];
-        projectId = parts[1];
-        pipelineId = parts[2];
+        orgId = parts[0] ?? orgId;
+        projectId = parts[1] ?? projectId;
+        pipelineId = parts[2] ?? "";
       } else {
-        pipelineId = parts[0];
+        pipelineId = parts[0] ?? "";
       }
 
       log.info("Fetching pipeline YAML", { pipelineId, orgId, projectId });

--- a/src/tools/diagnose/pipeline.ts
+++ b/src/tools/diagnose/pipeline.ts
@@ -371,7 +371,7 @@ function buildExecutionSummary(
   }
 
   if (failedNodes.length > 0) {
-    const primary = failedNodes[0];
+    const primary = failedNodes[0]!;
     const failureEntry = (f: FailedNodeDetail) => {
       const entry: Record<string, unknown> = {
         stage: f.stage,
@@ -472,7 +472,7 @@ export const pipelineHandler: DiagnoseHandler = {
         }, signal);
         const items = (execList as { items?: Array<Record<string, unknown>> }).items;
         if (items && items.length > 0) {
-          executionId = (items[0].planExecutionId as string) ?? undefined;
+          executionId = (items[0]!.planExecutionId as string) ?? undefined;
           input.execution_id = executionId;
         }
       } catch (err) {
@@ -517,7 +517,7 @@ export const pipelineHandler: DiagnoseHandler = {
               if (f.script_context) e.script_context = f.script_context;
               return e;
             };
-            const childPrimary = childFailedNodes[0];
+            const childPrimary = childFailedNodes[0]!;
             const execDiag = asRecord(diagnostic.execution) ?? {};
             execDiag.child_pipeline = {
               execution_id: result.childRef.executionId,

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -48,8 +48,9 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
         const { params, ...rest } = args;
         const input = applyUrlDefaults(rest as Record<string, unknown>, args.url);
         if (params) Object.assign(input, params);
-        if (def.identifierFields.length > 0 && args.resource_id) {
-          input[def.identifierFields[0]] = args.resource_id;
+        const primaryField = def.identifierFields[0];
+        if (primaryField && args.resource_id) {
+          input[primaryField] = args.resource_id;
         }
 
         const result = await registry.dispatch(client, args.resource_type, "delete", input);

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -63,8 +63,9 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         }
 
         // Map resource_id to the primary identifier field
-        if (def.identifierFields.length > 0 && resourceId) {
-          input[def.identifierFields[0]] = resourceId;
+        const primaryField = def.identifierFields[0];
+        if (primaryField && resourceId) {
+          input[primaryField] = resourceId;
         }
 
         let result: unknown;

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -40,8 +40,9 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
         const def = registry.getResource(resourceType);
 
         // Map resource_id to the primary identifier field
-        if (def.identifierFields.length > 0 && resourceId) {
-          input[def.identifierFields[0]] = resourceId;
+        const primaryField = def.identifierFields[0];
+        if (primaryField && resourceId) {
+          input[primaryField] = resourceId;
         }
 
         const result = await registry.dispatch(client, resourceType, "get", input);

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -49,8 +49,9 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
         const { params, ...rest } = args;
         const input = applyUrlDefaults(rest as Record<string, unknown>, args.url);
         if (params) Object.assign(input, params);
-        if (def.identifierFields.length > 0 && args.resource_id) {
-          input[def.identifierFields[0]] = args.resource_id;
+        const primaryField = def.identifierFields[0];
+        if (primaryField && args.resource_id) {
+          input[primaryField] = args.resource_id;
         }
         const versionLabel = asString(input.version_label);
         if (versionLabel) { /* already set via params */ }

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -72,7 +72,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
 function parseTransport(argv: string[]): Transport {
   // First positional arg that isn't a flag or flag value
   for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
+    const arg = argv[i]!;
     if (arg === "--port") {
       i++; // skip the value after --port
       continue;
@@ -93,7 +93,7 @@ function parsePort(argv: string[]): number {
   // Check --port flag first
   const portFlagIndex = argv.indexOf("--port");
   if (portFlagIndex !== -1 && portFlagIndex + 1 < argv.length) {
-    const parsed = Number(argv[portFlagIndex + 1]);
+    const parsed = Number(argv[portFlagIndex + 1]!);
     if (isValidPort(parsed)) return parsed;
   }
 

--- a/src/utils/url-parser.ts
+++ b/src/utils/url-parser.ts
@@ -87,29 +87,29 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
   // 1. Extract account_id
   const accountIdx = segments.indexOf("account");
   if (accountIdx >= 0 && accountIdx + 1 < segments.length) {
-    result.account_id = segments[accountIdx + 1];
+    result.account_id = segments[accountIdx + 1]!;
   }
 
   // 2. Extract module from /module/{name}/ pattern
   const moduleIdx = segments.indexOf("module");
   if (moduleIdx >= 0 && moduleIdx + 1 < segments.length) {
-    result.module = segments[moduleIdx + 1];
+    result.module = segments[moduleIdx + 1]!;
   }
 
   // 3. Extract org and project
   const orgsIdx = segments.indexOf("orgs");
   if (orgsIdx >= 0 && orgsIdx + 1 < segments.length) {
-    result.org_id = segments[orgsIdx + 1];
+    result.org_id = segments[orgsIdx + 1]!;
   }
   const projectsIdx = segments.indexOf("projects");
   if (projectsIdx >= 0 && projectsIdx + 1 < segments.length) {
-    result.project_id = segments[projectsIdx + 1];
+    result.project_id = segments[projectsIdx + 1]!;
   }
 
   // 4. Check for module after /all/ (e.g. /all/cd/orgs/...)
   const allIdx = segments.indexOf("all");
   if (allIdx >= 0 && !result.module && allIdx + 1 < segments.length) {
-    const afterAll = segments[allIdx + 1];
+    const afterAll = segments[allIdx + 1]!;
     if (MODULES.has(afterAll)) {
       result.module = afterAll;
     }
@@ -121,7 +121,7 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
   const matches: Array<{ type: string; contextField: string; id?: string }> = [];
 
   for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i];
+    const seg = segments[i]!;
     const def = RESOURCE_SEGMENTS[seg];
     if (!def) continue;
 
@@ -143,7 +143,7 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
 
   // 6. Build result — set context fields from all matches, resource_id from the primary
   if (matches.length > 0) {
-    const primary = matches[matches.length - 1];
+    const primary = matches[matches.length - 1]!;
     result.resource_type = primary.type;
 
     for (const match of matches) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "build",
     "rootDir": "src",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- Enable `noUncheckedIndexedAccess` in `tsconfig.json` so `obj[key]` and `arr[i]` return `T | undefined` at compile time
- Fix all 21 resulting type errors across 10 files:
  - **config.ts**: Extract `parts[1]` into variable with truthiness check
  - **pipeline-yaml.ts**: Add `?? ""` fallbacks for URI path parts
  - **cli.ts**: Non-null assertions on loop-guarded `argv[i]` and bounds-checked `argv[portFlagIndex + 1]`
  - **harness-{get,delete,execute,update}.ts**: Extract `identifierFields[0]` into variable with truthiness guard
  - **diagnose/pipeline.ts**: Non-null assertions on length-guarded `failedNodes[0]`, `items[0]`, `childFailedNodes[0]`
  - **url-parser.ts**: Non-null assertions on bounds-checked `segments[idx + 1]` and loop-indexed `segments[i]`

## Test plan
- [x] Type-check passes with new strictness
- [x] All 249 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)