### PR TITLE
fix: remove unsafe index signatures from internal interfaces

### DIFF
--- a/src/tools/diagnose/delegate.ts
+++ b/src/tools/diagnose/delegate.ts
@@ -24,7 +24,6 @@ interface DelegateInfo {
   legacy?: boolean;
   orgName?: string;
   projectName?: string;
-  [key: string]: unknown;
 }
 
 function analyzeDelegateHealth(delegate: DelegateInfo): {

--- a/src/tools/diagnose/gitops-application.ts
+++ b/src/tools/diagnose/gitops-application.ts
@@ -26,7 +26,6 @@ interface AppStatus {
   };
   summary?: { images?: string[] };
   resources?: Array<{ kind?: string; name?: string; namespace?: string; health?: { status?: string; message?: string }; status?: string }>;
-  [key: string]: unknown;
 }
 
 interface ResourceNode {
@@ -38,7 +37,6 @@ interface ResourceNode {
   health?: { status?: string; message?: string };
   info?: Array<{ name?: string; value?: string }>;
   parentRefs?: Array<{ kind?: string; name?: string; namespace?: string }>;
-  [key: string]: unknown;
 }
 
 function analyzeAppStatus(raw: Record<string, unknown>): Record<string, unknown> {

--- a/src/tools/harness-status.ts
+++ b/src/tools/harness-status.ts
@@ -20,13 +20,11 @@ interface ExecutionItem {
   status?: string;
   startTs?: number;
   endTs?: number;
-  [key: string]: unknown;
 }
 
 interface ListResult {
   items?: ExecutionItem[];
   total?: number;
-  [key: string]: unknown;
 }
 
 function summarizeExecution(

--- a/src/utils/response-formatter.ts
+++ b/src/utils/response-formatter.ts
@@ -3,6 +3,7 @@
  */
 
 export interface ToolResult {
+  /** Required: MCP SDK's CallToolResult extends Result which has an index signature. */
   [key: string]: unknown;
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;

--- a/src/utils/url-parser.ts
+++ b/src/utils/url-parser.ts
@@ -17,9 +17,18 @@ export interface ParsedHarnessUrl {
   registry_id?: string;
   artifact_id?: string;
   environment_id?: string;
-  /** Index signature allows dynamic contextField assignment from URL parsing. */
-  [key: string]: string | undefined;
 }
+
+/** Union of ParsedHarnessUrl fields that RESOURCE_SEGMENTS can write to. */
+type ContextField =
+  | "pipeline_id"
+  | "execution_id"
+  | "resource_id"
+  | "agent_id"
+  | "repo_id"
+  | "registry_id"
+  | "artifact_id"
+  | "environment_id";
 
 /** Known Harness module identifiers that appear in URL paths */
 const MODULES = new Set(["cd", "ci", "cf", "ce", "cv", "sto", "chaos", "idp", "sei"]);
@@ -28,7 +37,7 @@ const MODULES = new Set(["cd", "ci", "cf", "ce", "cv", "sto", "chaos", "idp", "s
  * Maps URL path segments (plural resource names) to registry resource types
  * and the field name used when the resource appears as parent context.
  */
-const RESOURCE_SEGMENTS: Record<string, { type: string; contextField: string }> = {
+const RESOURCE_SEGMENTS: Record<string, { type: string; contextField: ContextField }> = {
   "pipelines":        { type: "pipeline",            contextField: "pipeline_id" },
   "executions":       { type: "execution",           contextField: "execution_id" },
   "deployments":      { type: "execution",           contextField: "execution_id" },
@@ -118,7 +127,7 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
   // 5. Walk segments to find resource types and IDs.
   //    Each match records the resource type and optional ID.
   //    The last (deepest) match becomes the primary resource.
-  const matches: Array<{ type: string; contextField: string; id?: string }> = [];
+  const matches: Array<{ type: string; contextField: ContextField; id?: string }> = [];
 
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i]!;


### PR DESCRIPTION
## Summary
- Remove `[key: string]: unknown` from 5 interfaces (`ExecutionItem`, `ListResult`, `AppStatus`, `ResourceNode`, `DelegateInfo`) that defeated TypeScript type checking by making any property access valid
- Replace `[key: string]: string | undefined` on `ParsedHarnessUrl` with a typed `ContextField` union — `RESOURCE_SEGMENTS` contextField values are now checked at compile time against actual interface fields
- Retain index signature on `ToolResult` with explanatory comment — structurally required by MCP SDK's `CallToolResult extends Result` base type

## Test plan
- [x] Type-check passes
- [x] All 249 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)