### PR TITLE
fix: batch P1/P2 cleanups — config, rate limiter, logger, cache, resource errors

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export function extractAccountIdFromToken(apiKey: string): string | undefined {
   return undefined;
 }
 
-export const ConfigSchema = z.object({
+const RawConfigSchema = z.object({
   HARNESS_API_KEY: z.string().min(1, "HARNESS_API_KEY is required"),
   HARNESS_ACCOUNT_ID: z.string().optional(),
   HARNESS_BASE_URL: z.string().url().default("https://app.harness.io"),
@@ -29,7 +29,17 @@ export const ConfigSchema = z.object({
   HARNESS_READ_ONLY: z.coerce.boolean().default(false),
 });
 
-export type Config = z.infer<typeof ConfigSchema> & { HARNESS_ACCOUNT_ID: string };
+export const ConfigSchema = RawConfigSchema.transform((data) => {
+  const accountId = data.HARNESS_ACCOUNT_ID ?? extractAccountIdFromToken(data.HARNESS_API_KEY);
+  if (!accountId) {
+    throw new Error(
+      "HARNESS_ACCOUNT_ID is required when the API key is not a PAT (pat.<accountId>.<tokenId>.<secret>)",
+    );
+  }
+  return { ...data, HARNESS_ACCOUNT_ID: accountId };
+});
+
+export type Config = z.infer<typeof ConfigSchema>;
 
 export function loadConfig(): Config {
   const result = ConfigSchema.safeParse(process.env);
@@ -38,18 +48,5 @@ export function loadConfig(): Config {
     throw new Error(`Invalid configuration:\n${issues}`);
   }
 
-  const data = result.data;
-
-  // If HARNESS_ACCOUNT_ID not provided, try to extract from the API key
-  if (!data.HARNESS_ACCOUNT_ID) {
-    const extracted = extractAccountIdFromToken(data.HARNESS_API_KEY);
-    if (!extracted) {
-      throw new Error(
-        "HARNESS_ACCOUNT_ID is required when the API key is not a PAT (pat.<accountId>.<tokenId>.<secret>)",
-      );
-    }
-    data.HARNESS_ACCOUNT_ID = extracted;
-  }
-
-  return data as Config;
+  return result.data;
 }

--- a/src/resources/execution-summary.ts
+++ b/src/resources/execution-summary.ts
@@ -16,22 +16,33 @@ export function registerExecutionSummaryResource(server: McpServer, registry: Re
       mimeType: "application/json",
     },
     async (uri) => {
-      log.info("Fetching recent executions");
+      try {
+        log.info("Fetching recent executions");
 
-      const result = await registry.dispatch(client, "execution", "list", {
-        org_id: config.HARNESS_DEFAULT_ORG_ID,
-        project_id: config.HARNESS_DEFAULT_PROJECT_ID ?? "",
-        size: 10,
-        page: 0,
-      });
+        const result = await registry.dispatch(client, "execution", "list", {
+          org_id: config.HARNESS_DEFAULT_ORG_ID,
+          project_id: config.HARNESS_DEFAULT_PROJECT_ID ?? "",
+          size: 10,
+          page: 0,
+        });
 
-      return {
-        contents: [{
-          uri: uri.href,
-          mimeType: "application/json",
-          text: JSON.stringify(result, null, 2),
-        }],
-      };
+        return {
+          contents: [{
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (err) {
+        log.warn("Failed to fetch recent executions", { error: String(err) });
+        return {
+          contents: [{
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify({ error: String(err), items: [] }, null, 2),
+          }],
+        };
+      }
     },
   );
 }

--- a/src/resources/harness-schema.ts
+++ b/src/resources/harness-schema.ts
@@ -14,7 +14,12 @@ function buildSchemaUrl(name: SchemaName): string {
   return `${SCHEMA_BASE_URL}/${name}.json`;
 }
 
-const schemaCache = new Map<SchemaName, string>();
+let schemaCache = new Map<SchemaName, string>();
+
+/** Clear the schema cache (for testing). */
+function clearSchemaCache(): void {
+  schemaCache = new Map();
+}
 
 async function fetchSchema(name: SchemaName): Promise<string> {
   const cached = schemaCache.get(name);
@@ -89,4 +94,4 @@ export function registerHarnessSchemaResource(server: McpServer): void {
 }
 
 // Exported for testing
-export { VALID_SCHEMAS, buildSchemaUrl, isValidSchemaName, schemaCache };
+export { VALID_SCHEMAS, buildSchemaUrl, isValidSchemaName, clearSchemaCache };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -18,7 +18,14 @@ export function setLogLevel(level: LogLevel): void {
   globalLevel = level;
 }
 
-export function createLogger(module: string) {
+export interface Logger {
+  debug: (msg: string, data?: Record<string, unknown>) => void;
+  info: (msg: string, data?: Record<string, unknown>) => void;
+  warn: (msg: string, data?: Record<string, unknown>) => void;
+  error: (msg: string, data?: Record<string, unknown>) => void;
+}
+
+export function createLogger(module: string): Logger {
   function log(level: LogLevel, message: string, data?: Record<string, unknown>): void {
     if (LOG_LEVELS[level] < LOG_LEVELS[globalLevel]) return;
 

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -1,6 +1,9 @@
 /**
  * Token-bucket rate limiter. Default: 10 requests/second.
  */
+
+const MAX_WAIT_MS = 30_000;
+
 export class RateLimiter {
   private tokens: number;
   private lastRefill: number;
@@ -14,7 +17,9 @@ export class RateLimiter {
   }
 
   async acquire(): Promise<void> {
-    while (true) {
+    const deadline = Date.now() + MAX_WAIT_MS;
+
+    while (Date.now() < deadline) {
       this.refill();
       if (this.tokens >= 1) {
         this.tokens -= 1;
@@ -24,6 +29,8 @@ export class RateLimiter {
       const waitMs = Math.ceil((1 - this.tokens) / this.refillRatePerMs);
       await new Promise((resolve) => setTimeout(resolve, waitMs));
     }
+
+    throw new Error(`Rate limiter: timed out waiting ${MAX_WAIT_MS}ms for a token`);
   }
 
   private refill(): void {

--- a/tests/resources/harness-schema.test.ts
+++ b/tests/resources/harness-schema.test.ts
@@ -3,12 +3,12 @@ import {
   VALID_SCHEMAS,
   buildSchemaUrl,
   isValidSchemaName,
-  schemaCache,
+  clearSchemaCache,
 } from "../../src/resources/harness-schema.js";
 
 describe("harness-schema resource", () => {
   beforeEach(() => {
-    schemaCache.clear();
+    clearSchemaCache();
   });
 
   describe("VALID_SCHEMAS", () => {


### PR DESCRIPTION
## Summary
Addresses 6 engineering feedback items:

- **Config type lie (P2)**: Replace `as Config` assertion with Zod `.transform()` that resolves `HARNESS_ACCOUNT_ID` at parse time — the output type is now truthful
- **Unbounded rate-limiter loop (P2)**: Add 30s deadline to `acquire()` — throws instead of spinning forever
- **No Logger interface (P2)**: Export `Logger` interface from `logger.ts` so function params can be typed
- **Mutable exported schemaCache (P2)**: Replace raw `Map` export with `clearSchemaCache()` function to prevent test pollution
- **Inconsistent resource error handling (P1)**: Add try/catch to `execution-summary.ts` matching `pipeline-yaml.ts` pattern
- **Inconsistent tool error handling (P1)**: Audited all 10 tool files — 9/9 already follow `errorResult + toMcpError` convention; `harness_describe` has intentional exception (returns fallback summary, no API calls)

## Test plan
- [x] Type-check passes
- [x] All 249 tests pass
- [x] Build succeeds
- [x] Updated `harness-schema.test.ts` to use `clearSchemaCache()` instead of `schemaCache.clear()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)