### PR TITLE
fix: batch P1/P2 packaging — docs, schema timeout, NOTICE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ harness-mcp-server/
 
 ### Authentication
 ```
-Header: x-api-key: <HARNESS_API_TOKEN>
+Header: x-api-key: <HARNESS_API_KEY>
 Base URL: https://app.harness.io
 ```
 - Personal API tokens or Service Account tokens
@@ -268,7 +268,7 @@ annotations: {
 
 ```bash
 # .env — required
-HARNESS_API_TOKEN=pat.xxxxx.xxxxx.xxxxx        # Personal access token or SA token
+HARNESS_API_KEY=pat.xxxxx.xxxxx.xxxxx           # Personal access token or SA token
 HARNESS_ACCOUNT_ID=abc123xyz                    # Account identifier
 HARNESS_BASE_URL=https://app.harness.io         # Override for self-managed
 
@@ -285,7 +285,7 @@ LOG_LEVEL=info                                  # debug | info | warn | error
 import { z } from "zod";
 
 export const ConfigSchema = z.object({
-  HARNESS_API_TOKEN: z.string().min(1, "API token required"),
+  HARNESS_API_KEY: z.string().min(1, "API key required"),
   HARNESS_ACCOUNT_ID: z.string().min(1, "Account ID required"),
   HARNESS_BASE_URL: z.string().url().default("https://app.harness.io"),
   HARNESS_DEFAULT_ORG: z.string().default("default"),
@@ -561,7 +561,7 @@ Add to Claude Desktop config (`claude_desktop_config.json`):
       "command": "node",
       "args": ["/path/to/harness-mcp-server/build/index.js"],
       "env": {
-        "HARNESS_API_TOKEN": "pat.xxx.xxx.xxx",
+        "HARNESS_API_KEY": "pat.xxx.xxx.xxx",
         "HARNESS_ACCOUNT_ID": "your-account-id",
         "HARNESS_DEFAULT_ORG": "default",
         "HARNESS_DEFAULT_PROJECT": "your-project"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,30 @@ In `src/registry/index.ts`:
 
 **executeActions** add non-CRUD operations like "run pipeline" or "toggle feature flag". They work like operations but are dispatched via `harness_execute`.
 
+### 5. bodySchema — required for create/update operations
+
+Any operation that sends a request body (`create`, `update`, execute actions with payloads) **must** include a `bodySchema` string. This is surfaced by `harness_describe` so the LLM knows what shape to send. Keep it concise — just the essential fields.
+
+```typescript
+operations: {
+  create: {
+    method: "POST",
+    path: "/api/resources",
+    bodySchema: '{ "name": string, "identifier": string, "type": "K8s" | "Docker", "spec": { ... } }',
+    description: "Create a resource",
+  },
+},
+```
+
+### 6. Avoiding parameter bloat
+
+Each resource type adds to the `harness_describe` output that the LLM must process. Keep definitions lean:
+
+- **identifierFields**: Only the primary key(s). Don't add fields that are just query params.
+- **listFilterFields**: Only fields the LLM would realistically use to narrow results. Skip internal API params like `sort` or `getDistinctFromBranches`.
+- **queryParams**: Map only the params that matter. The registry auto-injects `accountIdentifier`, `orgIdentifier`, and `projectIdentifier` based on `scope`.
+- **responseExtractor**: Always unwrap the Harness envelope (`data`, `data.content`). Don't return raw responses — they contain pagination metadata the LLM doesn't need.
+
 ## Adding a Prompt Template
 
 Prompt templates live in `src/prompts/`. Each file exports a `register*Prompt(server)` function.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,25 @@
+Harness MCP Server
+Copyright 2024-2026 Rohan Gupta
+
+This product includes software developed by third parties.
+
+=======================================================================
+Third-Party Dependencies (Runtime)
+=======================================================================
+
+@modelcontextprotocol/sdk
+  Copyright Anthropic, PBC
+  Licensed under the MIT License
+  https://github.com/modelcontextprotocol/typescript-sdk
+
+Express
+  Copyright (c) 2009-2014 TJ Holowaychuk
+  Copyright (c) 2013-2014 Roman Shtylman
+  Copyright (c) 2014-2015 Douglas Christopher Wilson
+  Licensed under the MIT License
+  https://github.com/expressjs/express
+
+Zod
+  Copyright (c) 2020 Colin McDonnell
+  Licensed under the MIT License
+  https://github.com/colinhacks/zod

--- a/src/resources/harness-schema.ts
+++ b/src/resources/harness-schema.ts
@@ -10,6 +10,8 @@ type SchemaName = (typeof VALID_SCHEMAS)[number];
 const SCHEMA_BASE_URL =
   "https://raw.githubusercontent.com/harness/harness-schema/main/v0";
 
+const SCHEMA_FETCH_TIMEOUT_MS = 10_000;
+
 function buildSchemaUrl(name: SchemaName): string {
   return `${SCHEMA_BASE_URL}/${name}.json`;
 }
@@ -31,7 +33,7 @@ async function fetchSchema(name: SchemaName): Promise<string> {
   const url = buildSchemaUrl(name);
   log.info("Fetching schema from GitHub", { name, url });
 
-  const response = await fetch(url);
+  const response = await fetch(url, { signal: AbortSignal.timeout(SCHEMA_FETCH_TIMEOUT_MS) });
   if (!response.ok) {
     throw new Error(
       `Failed to fetch schema '${name}': HTTP ${response.status} ${response.statusText}`,


### PR DESCRIPTION
## Summary
Addresses 6 engineering feedback items:

- **Config naming mismatch (P2)**: Fix `CLAUDE.md` to use `HARNESS_API_KEY` (matching actual code) instead of `HARNESS_API_TOKEN` in all 4 occurrences
- **Schema fetch no timeout (P2)**: Add 10s `AbortSignal.timeout` to GitHub schema fetch in `harness-schema.ts` — prevents hanging when offline
- **No NOTICE file (P2)**: Add Apache-2.0 third-party attribution for runtime dependencies (`@modelcontextprotocol/sdk`, Express, Zod)
- **CONTRIBUTING.md lacks toolset guide (P2)**: Add sections on `bodySchema` requirement for create/update operations and parameter bloat risk
- **No bin in package.json (P1)**: Already present — `bin` field + `#!/usr/bin/env node` shebang verified in build output
- **Missing engines field (P2)**: Already present — `"engines": { "node": ">=20.0.0" }`

## Test plan
- [x] Type-check passes
- [x] All 249 tests pass
- [x] Build succeeds
- [x] Verified `HARNESS_API_TOKEN` fully removed from CLAUDE.md
- [x] Verified shebang preserved in `build/index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)