### PR TITLE
feat: smart pre-flight validation and input guidance for pipeline execution

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -113,6 +113,9 @@ export class Registry {
     return new Set(valid);
   }
 
+  get defaultOrgId(): string { return this.config.HARNESS_DEFAULT_ORG_ID; }
+  get defaultProjectId(): string | undefined { return this.config.HARNESS_DEFAULT_PROJECT_ID; }
+
   /** Get a resource definition by type, or throw. */
   getResource(resourceType: string): ResourceDefinition {
     const def = this.resourceMap.get(resourceType);

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -42,6 +42,7 @@ export const pipelinesToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["pipeline_id"],
       diagnosticHint: "Use harness_diagnose with pipeline_id or execution_id to analyze failures — includes step-level error details, log snippets, delegate info, and chained pipeline traversal.",
+      executeHint: "Before executing, check required inputs: harness_get(resource_type='runtime_input_template', resource_id='PIPELINE_ID'). For simple variables, pass key-value pairs in inputs. For complex pipelines (CI codebase build, templates), use input_set_ids — list available sets with harness_list(resource_type='input_set', filters={pipeline_id: '...'}).",
       listFilterFields: ["search_term", "module", "filter_type"],
       deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/pipelines/{pipelineIdentifier}/pipeline-studio",
       operations: {
@@ -126,12 +127,12 @@ export const pipelinesToolset: ToolsetDefinition = {
             return JSON.stringify(inputs);
           },
           responseExtractor: ngExtract,
-          actionDescription: "Execute/run a pipeline. For runtime inputs, pass simple key-value pairs (e.g. {branch: 'main', env: 'prod'}) and they will be auto-resolved against the pipeline's input template. Alternatively, pass a full runtime input YAML string, or use input_set_ids to reference saved input sets.",
+          actionDescription: "Execute/run a pipeline. RECOMMENDED: first check harness_get(resource_type='runtime_input_template', resource_id='PIPELINE_ID') to see required inputs. For simple variable inputs: pass key-value pairs in inputs (e.g. {branch: 'main'}) — auto-resolved. For complex pipelines with structural inputs (CI codebase build, template inputs): use input_set_ids to reference a saved input set. List available sets with harness_list(resource_type='input_set', filters={pipeline_id: '...'}).",
           bodySchema: {
-            description: "Runtime inputs for pipeline execution. Three options: (1) Simple key-value pairs — auto-resolved against the pipeline's input template (easiest). (2) Named input set references via input_set_ids param. (3) Full runtime input YAML string (advanced). If the pipeline has no runtime inputs, omit the inputs field.",
+            description: "Runtime inputs for pipeline execution. Two strategies: (1) For simple variables — pass key-value pairs in inputs like {branch: 'main', env: 'prod'}, auto-resolved against the pipeline's runtime input template. (2) For complex pipelines with structural fields (CI codebase build config, template inputs) — use input_set_ids to reference saved input sets. You can combine both: input_set_ids for the base config + inputs for simple overrides. Check runtime_input_template first to see what the pipeline expects.",
             fields: [
-              { name: "inputs", type: "yaml", required: false, description: "Simple key-value pairs (e.g. {branch: 'main', env: 'prod'}) — auto-resolved to full YAML. Or a full runtime input YAML string. Or a JSON object with nested pipeline structure." },
-              { name: "input_set_ids", type: "array", required: false, description: "Array of input set identifiers to apply (references saved input sets). Passed as query parameter." },
+              { name: "inputs", type: "yaml", required: false, description: "Simple key-value pairs (e.g. {branch: 'main', env: 'prod'}) — auto-resolved to full YAML. Works best for pipeline variables. For structural fields like CI codebase build, use input_set_ids instead." },
+              { name: "input_set_ids", type: "array", required: false, description: "Input set identifiers to apply. Recommended for complex pipelines with structural inputs. List available: harness_list(resource_type='input_set', filters={pipeline_id: '...'})." },
             ],
           },
         },

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -108,6 +108,8 @@ export interface ResourceDefinition {
   deepLinkTemplate?: string;
   /** Troubleshooting guidance for LLMs. Describes how to diagnose issues with this resource type. */
   diagnosticHint?: string;
+  /** Execution guidance for LLMs. Describes how to discover and provide runtime inputs. */
+  executeHint?: string;
   /** CRUD endpoint mappings */
   operations: Partial<Record<OperationName, EndpointSpec>>;
   /** Execute action mappings (e.g. run pipeline, toggle FF) */

--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -46,6 +46,7 @@ export function registerDescribeTool(server: McpServer, registry: Registry): voi
                 }))
               : undefined,
             diagnosticHint: def.diagnosticHint ?? undefined,
+            executeHint: def.executeHint ?? undefined,
           });
         } catch (err) {
           // Resource type not found — return the compact summary with an error hint

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -8,7 +8,7 @@ import { confirmViaElicitation } from "../utils/elicitation.js";
 import { createLogger } from "../utils/logger.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asRecord, asString } from "../utils/type-guards.js";
-import { isFlatKeyValueInputs, resolveRuntimeInputs } from "../utils/runtime-input-resolver.js";
+import { isFlatKeyValueInputs, resolveRuntimeInputs, type ResolutionResult } from "../utils/runtime-input-resolver.js";
 
 const log = createLogger("execute");
 
@@ -24,8 +24,8 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         resource_id: z.string().describe("The primary identifier of the resource").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
-        inputs: z.union([z.string(), z.record(z.string(), z.unknown())]).describe("Runtime inputs for pipeline execution. Easiest: pass simple key-value pairs like {branch: 'main', env: 'prod'} — they are auto-resolved against the pipeline's input template. Alternative: pass a full runtime input YAML string. For pipelines with no runtime inputs, omit this field.").optional(),
-        input_set_ids: z.array(z.string()).describe("Input set identifiers to apply when running a pipeline. References saved input sets by ID.").optional(),
+        inputs: z.union([z.string(), z.record(z.string(), z.unknown())]).describe("Runtime inputs for pipeline execution. For simple variables: pass key-value pairs like {branch: 'main', env: 'prod'} — auto-resolved against the pipeline's input template. For complex pipelines (CI codebase, templates with structural fields): use input_set_ids instead, or provide full runtime input YAML. Check harness_get(resource_type='runtime_input_template', resource_id='PIPELINE_ID') first to see what inputs are needed.").optional(),
+        input_set_ids: z.array(z.string()).describe("Input set identifiers to apply when running a pipeline. Recommended for complex pipelines with structural inputs (CI codebase build config, template inputs). List available sets with harness_list(resource_type='input_set', filters={pipeline_id: 'PIPELINE_ID'}).").optional(),
         body: z.record(z.string(), z.unknown()).describe("Additional body payload for the action").optional(),
         params: z.record(z.string(), z.unknown()).describe("Action-specific parameters (e.g. pipeline_id, execution_id, flag_id, agent_id, interrupt_type, enable, environment, module). Call harness_describe for available actions and fields per resource_type.").optional(),
       },
@@ -76,6 +76,9 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         }
 
         // Auto-resolve flat key-value runtime inputs for pipeline run
+        let resolved: ResolutionResult | undefined;
+        const hasInputSets = args.input_set_ids && args.input_set_ids.length > 0;
+
         if (
           resourceType === "pipeline" &&
           args.action === "run" &&
@@ -86,19 +89,45 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
             return errorResult("pipeline_id is required to auto-resolve runtime inputs. Provide it via resource_id, params.pipeline_id, or a Harness URL.");
           }
           try {
-            const resolved = await resolveRuntimeInputs(client, args.inputs, {
+            resolved = await resolveRuntimeInputs(client, args.inputs, {
               pipelineId,
-              orgId: asString(input.org_id),
-              projectId: asString(input.project_id),
+              orgId: asString(input.org_id) || registry.defaultOrgId,
+              projectId: asString(input.project_id) || registry.defaultProjectId,
             });
-            input.inputs = resolved.yaml;
-            // Attach resolution metadata for the LLM
-            if (resolved.unmatched.length > 0) {
-              log.warn(`Unresolved runtime input placeholders: ${resolved.unmatched.join(", ")}`);
+
+            // Smart pre-flight: only block on required unmatched fields when no input sets cover them
+            if (!hasInputSets && resolved.unmatchedRequired.length > 0) {
+              const parts: string[] = [];
+              if (resolved.matched.length > 0) {
+                parts.push(`Matched ${resolved.matched.length} input(s): ${resolved.matched.join(", ")}.`);
+              }
+
+              const structuralFields = resolved.unmatchedRequired.filter(f => isStructuralField(f));
+              const simpleFields = resolved.unmatchedRequired.filter(f => !isStructuralField(f));
+
+              parts.push(`${resolved.unmatchedRequired.length} required field(s) still need values: ${resolved.unmatchedRequired.join(", ")}.`);
+
+              if (structuralFields.length > 0) {
+                parts.push(`Fields [${structuralFields.join(", ")}] likely need complex objects (not simple strings). Use an input set or provide full YAML.`);
+              }
+
+              if (resolved.unmatchedOptional.length > 0) {
+                parts.push(`${resolved.unmatchedOptional.length} optional field(s) have defaults and can be omitted: ${resolved.unmatchedOptional.join(", ")}.`);
+              }
+
+              // Fetch available input sets to suggest them
+              const inputSetHint = await fetchInputSetHint(client, pipelineId, input, registry);
+              if (inputSetHint) parts.push(inputSetHint);
+
+              parts.push(`Expected keys: [${resolved.expectedKeys.join(", ")}]. You provided: [${Object.keys(args.inputs).join(", ")}].`);
+              parts.push(`Tip: use harness_get(resource_type="runtime_input_template", resource_id="${pipelineId}") to see the full template.`);
+
+              return errorResult(parts.join("\n\n"));
             }
+
+            input.inputs = resolved.yaml;
           } catch (err) {
             log.warn("Failed to auto-resolve runtime inputs, passing through as-is", { error: String(err) });
-            // Fall through — let the original inputs pass to the API
           }
         }
 
@@ -116,7 +145,6 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
             log.info("Retry returned 405, falling back to fresh pipeline run");
             let pipelineId = asString(input.pipeline_id);
 
-            // Resolve pipeline_id from execution if not provided
             if (!pipelineId && input.execution_id) {
               try {
                 const exec = asRecord(await registry.dispatch(client, "execution", "get", input));
@@ -138,6 +166,17 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           throw err;
         }
 
+        if (resolved) {
+          return jsonResult({
+            ...(asRecord(result) ?? {}),
+            _inputResolution: {
+              mode: hasInputSets ? "input_set_with_overrides" : "auto_resolved",
+              matched: resolved.matched,
+              ...(resolved.unmatchedOptional.length > 0 ? { defaulted: resolved.unmatchedOptional } : {}),
+            },
+          });
+        }
+
         return jsonResult(result);
       } catch (err) {
         if (isUserError(err)) return errorResult(err.message);
@@ -146,4 +185,46 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
       }
     },
   );
+}
+
+const STRUCTURAL_FIELDS = new Set([
+  "build", "infrastructure", "execution", "spec", "template",
+  "templateinputs", "servicedefinition", "artifacts", "manifests",
+]);
+
+function isStructuralField(fieldName: string): boolean {
+  return STRUCTURAL_FIELDS.has(fieldName.toLowerCase());
+}
+
+async function fetchInputSetHint(
+  client: HarnessClient,
+  pipelineId: string,
+  input: Record<string, unknown>,
+  registry: Registry,
+): Promise<string | null> {
+  try {
+    const raw = await client.request<unknown>({
+      method: "GET",
+      path: "/pipeline/api/inputSets",
+      params: {
+        pipelineIdentifier: pipelineId,
+        orgIdentifier: String(input.org_id || registry.defaultOrgId),
+        projectIdentifier: String(input.project_id || registry.defaultProjectId),
+        size: "5",
+      },
+    });
+    const data = asRecord(asRecord(raw)?.data);
+    const content = data?.content;
+    if (!Array.isArray(content) || content.length === 0) return null;
+
+    const ids = content
+      .map((item: unknown) => asString(asRecord(item)?.identifier))
+      .filter(Boolean);
+    if (ids.length === 0) return null;
+
+    const total = typeof data?.totalElements === "number" ? data.totalElements : ids.length;
+    return `Available input sets for this pipeline (${total} total): [${ids.join(", ")}]. Use input_set_ids=["<id>"] to apply one.`;
+  } catch {
+    return null;
+  }
 }

--- a/src/utils/runtime-input-resolver.ts
+++ b/src/utils/runtime-input-resolver.ts
@@ -16,12 +16,21 @@ import { isRecord, asRecord, asString } from "./type-guards.js";
 const log = createLogger("runtime-inputs");
 
 const INPUT_PLACEHOLDER = /^<\+input>\.?/;
+const HAS_DEFAULT = /^<\+input>\.default\(/;
 
-interface ResolveOptions {
+export interface ResolveOptions {
   pipelineId: string;
   orgId?: string;
   projectId?: string;
   branch?: string;
+}
+
+export interface ResolutionResult {
+  yaml: string;
+  matched: string[];
+  unmatchedRequired: string[];
+  unmatchedOptional: string[];
+  expectedKeys: string[];
 }
 
 interface TemplateResponse {
@@ -90,12 +99,13 @@ export function isFlatKeyValueInputs(inputs: unknown): inputs is Record<string, 
 export function substituteInputs(
   templateYaml: string,
   userInputs: Record<string, unknown>,
-): { yaml: string; matched: string[]; unmatched: string[] } {
+): ResolutionResult {
   const doc = YAML.parseDocument(templateYaml);
   const matched: string[] = [];
-  const unmatched: string[] = [];
+  const unmatchedRequired: string[] = [];
+  const unmatchedOptional: string[] = [];
+  const expectedKeys: string[] = [];
 
-  // Build a case-insensitive lookup from user inputs
   const normalizedInputs = new Map<string, unknown>();
   for (const [key, value] of Object.entries(userInputs)) {
     normalizedInputs.set(key.toLowerCase(), value);
@@ -131,22 +141,27 @@ export function substituteInputs(
     } else if (YAML.isScalar(node)) {
       const val = String(node.value);
       if (INPUT_PLACEHOLDER.test(val)) {
-        const leafKey = path[path.length - 1]?.toLowerCase() ?? "";
+        const rawLeafKey = path[path.length - 1] ?? "";
+        const leafKey = rawLeafKey.toLowerCase();
         const fullPath = path.join(".").toLowerCase();
+        const isOptional = HAS_DEFAULT.test(val);
 
-        // For variable-style entries (value: "<+input>"), use sibling "name" field
-        let variableName: string | undefined;
+        let variableNameRaw: string | undefined;
+        let variableNameLower: string | undefined;
         if ((leafKey === "value" || leafKey === "default") && parentMap) {
-          variableName = getSiblingName(parentMap)?.toLowerCase();
+          variableNameRaw = getSiblingName(parentMap);
+          variableNameLower = variableNameRaw?.toLowerCase();
         }
 
-        // Try matching order: variable name → leaf key → full path
+        const bestKey = variableNameRaw ?? rawLeafKey ?? path.join(".");
+        expectedKeys.push(bestKey);
+
         let replacement: unknown = undefined;
         let matchedAs: string | undefined;
 
-        if (variableName && normalizedInputs.has(variableName)) {
-          replacement = normalizedInputs.get(variableName);
-          matchedAs = variableName;
+        if (variableNameLower && normalizedInputs.has(variableNameLower)) {
+          replacement = normalizedInputs.get(variableNameLower);
+          matchedAs = variableNameLower;
         } else if (normalizedInputs.has(leafKey)) {
           replacement = normalizedInputs.get(leafKey);
           matchedAs = leafKey;
@@ -155,12 +170,14 @@ export function substituteInputs(
           matchedAs = fullPath;
         }
 
-        const displayName = variableName ?? path[path.length - 1] ?? fullPath;
+        const displayName = variableNameRaw ?? rawLeafKey ?? path.join(".");
         if (replacement !== undefined) {
           node.value = replacement;
           matched.push(matchedAs ?? displayName);
+        } else if (isOptional) {
+          unmatchedOptional.push(displayName);
         } else {
-          unmatched.push(displayName);
+          unmatchedRequired.push(displayName);
         }
       }
     }
@@ -171,7 +188,9 @@ export function substituteInputs(
   return {
     yaml: doc.toString(),
     matched,
-    unmatched,
+    unmatchedRequired,
+    unmatchedOptional,
+    expectedKeys,
   };
 }
 
@@ -180,19 +199,20 @@ export function substituteInputs(
  * Returns the resolved YAML string ready for the pipeline execute API.
  *
  * If the pipeline has no runtime inputs, returns an empty string.
- * If some inputs couldn't be matched, includes a warning in the _meta field.
+ * unmatchedRequired: placeholders that MUST be provided (will cause API 400).
+ * unmatchedOptional: placeholders with .default() — the API fills them in.
  */
 export async function resolveRuntimeInputs(
   client: HarnessClient,
   flatInputs: Record<string, unknown>,
   options: ResolveOptions,
-): Promise<{ yaml: string; matched: string[]; unmatched: string[] }> {
+): Promise<ResolutionResult> {
   log.info(`Resolving runtime inputs for pipeline ${options.pipelineId}`);
 
   const templateYaml = await fetchRuntimeInputTemplate(client, options);
   if (!templateYaml) {
     log.info("Pipeline has no runtime inputs, ignoring user-provided inputs");
-    return { yaml: "", matched: [], unmatched: Object.keys(flatInputs) };
+    return { yaml: "", matched: [], unmatchedRequired: [], unmatchedOptional: [], expectedKeys: [] };
   }
 
   log.debug("Template YAML fetched", { templateLength: templateYaml.length });
@@ -202,8 +222,11 @@ export async function resolveRuntimeInputs(
   if (result.matched.length > 0) {
     log.info(`Resolved ${result.matched.length} runtime inputs: ${result.matched.join(", ")}`);
   }
-  if (result.unmatched.length > 0) {
-    log.warn(`${result.unmatched.length} template placeholders unresolved: ${result.unmatched.join(", ")}`);
+  if (result.unmatchedRequired.length > 0) {
+    log.warn(`${result.unmatchedRequired.length} required placeholders unresolved: ${result.unmatchedRequired.join(", ")}`);
+  }
+  if (result.unmatchedOptional.length > 0) {
+    log.debug(`${result.unmatchedOptional.length} optional placeholders (have defaults): ${result.unmatchedOptional.join(", ")}`);
   }
 
   return result;

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -383,6 +383,143 @@ describe("harness_execute", () => {
     const data = parseResult(result) as { _note: string };
     expect(data._note).toContain("fresh pipeline run");
   });
+
+  it("blocks when flat inputs have unmatchedRequired and no input_set_ids", async () => {
+    // Template fetch returns a template with required + optional fields
+    const mixedTemplate = `pipeline:
+  identifier: "test_pipe"
+  properties:
+    ci:
+      codebase:
+        build: "<+input>"
+  variables:
+    - name: "DEPLOY"
+      type: "String"
+      value: "<+input>.default(true)"
+`;
+    mockRequest
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { inputSetTemplateYaml: mixedTemplate } }) // template fetch
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { content: [{ identifier: "my-set" }], totalElements: 1 } }); // input set list
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "test_pipe",
+      inputs: { WRONG_KEY: "value" },
+    });
+
+    expect(result.isError).toBe(true);
+    const errText = JSON.stringify(parseResult(result));
+    expect(errText).toContain("required field");
+    expect(errText).toContain("build");
+    expect(errText).toContain("Expected keys");
+  });
+
+  it("allows execution when only unmatchedOptional remain", async () => {
+    const optionalTemplate = `pipeline:
+  identifier: "opt_pipe"
+  variables:
+    - name: "DEPLOY"
+      type: "String"
+      value: "<+input>.default(true)"
+    - name: "BUILD"
+      type: "String"
+      value: "<+input>.default(false)"
+`;
+    mockRequest
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { inputSetTemplateYaml: optionalTemplate } }) // template
+      .mockResolvedValueOnce({ data: { planExecutionId: "exec-opt" } }); // execute
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "opt_pipe",
+      inputs: {},
+    });
+
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("skips pre-flight when input_set_ids are present", async () => {
+    const templateWithRequired = `pipeline:
+  identifier: "skip_pipe"
+  variables:
+    - name: "branch"
+      type: "String"
+      value: "<+input>"
+`;
+    mockRequest
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { inputSetTemplateYaml: templateWithRequired } }) // template
+      .mockResolvedValueOnce({ data: { planExecutionId: "exec-skip" } }); // execute
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "skip_pipe",
+      inputs: {},
+      input_set_ids: ["my-input-set"],
+    });
+
+    // Should NOT error even though "branch" is required and unmatched,
+    // because input_set_ids are present to cover it
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("includes _inputResolution metadata on successful auto-resolved execution", async () => {
+    const simpleTemplate = `pipeline:
+  identifier: "meta_pipe"
+  variables:
+    - name: "tag"
+      type: "String"
+      value: "<+input>"
+    - name: "REGISTRY"
+      type: "String"
+      value: "<+input>.default(docker.io)"
+`;
+    mockRequest
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { inputSetTemplateYaml: simpleTemplate } }) // template
+      .mockResolvedValueOnce({ data: { planExecutionId: "exec-meta" } }); // execute
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "meta_pipe",
+      inputs: { tag: "v1.0" },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result) as { _inputResolution: { mode: string; matched: string[]; defaulted?: string[] } };
+    expect(data._inputResolution).toBeDefined();
+    expect(data._inputResolution.mode).toBe("auto_resolved");
+    expect(data._inputResolution.matched).toContain("tag");
+    expect(data._inputResolution.defaulted).toContain("REGISTRY");
+  });
+
+  it("includes structural field hints in pre-flight error", async () => {
+    const structuralTemplate = `pipeline:
+  identifier: "struct_pipe"
+  properties:
+    ci:
+      codebase:
+        build: "<+input>"
+        repoName: "<+input>"
+`;
+    mockRequest
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { inputSetTemplateYaml: structuralTemplate } }) // template
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { content: [], totalElements: 0 } }); // input set list (empty)
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "struct_pipe",
+      inputs: { something: "wrong" },
+    });
+
+    expect(result.isError).toBe(true);
+    const errText = JSON.stringify(parseResult(result));
+    expect(errText).toContain("build");
+    expect(errText).toContain("complex object");
+  });
 });
 
 describe("harness_describe", () => {

--- a/tests/utils/runtime-input-resolver.test.ts
+++ b/tests/utils/runtime-input-resolver.test.ts
@@ -21,7 +21,6 @@ function makeConfig(): Config {
   };
 }
 
-// A realistic runtime input template YAML from Harness
 const SAMPLE_TEMPLATE_YAML = `pipeline:
   identifier: "my_pipeline"
   stages:
@@ -51,6 +50,39 @@ const SIMPLE_TEMPLATE_YAML = `pipeline:
     - name: "tag"
       type: "String"
       value: "<+input>"
+`;
+
+const MIXED_TEMPLATE_YAML = `pipeline:
+  identifier: "mixed_pipe"
+  properties:
+    ci:
+      codebase:
+        repoName: "<+input>"
+        build: "<+input>"
+  variables:
+    - name: "SERVICE_LIST"
+      type: "String"
+      value: "<+input>"
+    - name: "DEPLOY"
+      type: "String"
+      value: "<+input>.default(true).allowedValues(true,false)"
+    - name: "HAR_REGISTRY"
+      type: "String"
+      value: "<+input>.default(https://registry.example.com)"
+`;
+
+const DEFAULTS_ONLY_TEMPLATE_YAML = `pipeline:
+  identifier: "defaults_pipe"
+  variables:
+    - name: "JAVA_BUILD"
+      type: "String"
+      value: "<+input>.default(true).allowedValues(true, false)"
+    - name: "PYTHON_BUILD"
+      type: "String"
+      value: "<+input>.default(false).allowedValues(true, false)"
+    - name: "NPM_BUILD"
+      type: "String"
+      value: "<+input>.default(false).selectOneFrom(true,false)"
 `;
 
 describe("isFlatKeyValueInputs", () => {
@@ -102,8 +134,7 @@ describe("substituteInputs", () => {
     expect(result.matched).toContain("environment");
     expect(result.yaml).toContain("main");
     expect(result.yaml).toContain("production");
-    // "image" placeholder was not matched — still has <+input>
-    expect(result.unmatched).toContain("image");
+    expect(result.unmatchedRequired).toContain("image");
     expect(result.matched).toHaveLength(2);
   });
 
@@ -115,7 +146,8 @@ describe("substituteInputs", () => {
     });
 
     expect(result.matched).toHaveLength(3);
-    expect(result.unmatched).toHaveLength(0);
+    expect(result.unmatchedRequired).toHaveLength(0);
+    expect(result.unmatchedOptional).toHaveLength(0);
     expect(result.yaml).not.toContain("<+input>");
   });
 
@@ -128,11 +160,14 @@ describe("substituteInputs", () => {
     expect(result.yaml).toContain("v1.0.0");
   });
 
-  it("returns unmatched for missing user inputs", () => {
+  it("returns unmatchedRequired for missing user inputs on required fields", () => {
     const result = substituteInputs(SAMPLE_TEMPLATE_YAML, {});
 
     expect(result.matched).toHaveLength(0);
-    expect(result.unmatched.length).toBeGreaterThan(0);
+    expect(result.unmatchedRequired.length).toBeGreaterThan(0);
+    expect(result.unmatchedRequired).toContain("branch");
+    expect(result.unmatchedRequired).toContain("environment");
+    expect(result.unmatchedRequired).toContain("image");
   });
 
   it("preserves YAML structure", () => {
@@ -168,6 +203,83 @@ describe("substituteInputs", () => {
 
     expect(result.matched).toContain("debug");
     expect(result.yaml).toContain("true");
+  });
+
+  it("classifies <+input>.default(...) as optional", () => {
+    const result = substituteInputs(MIXED_TEMPLATE_YAML, {});
+
+    expect(result.unmatchedRequired).toContain("repoName");
+    expect(result.unmatchedRequired).toContain("build");
+    expect(result.unmatchedRequired).toContain("SERVICE_LIST");
+    expect(result.unmatchedOptional).toContain("DEPLOY");
+    expect(result.unmatchedOptional).toContain("HAR_REGISTRY");
+    expect(result.unmatchedRequired).toHaveLength(3);
+    expect(result.unmatchedOptional).toHaveLength(2);
+  });
+
+  it("classifies <+input>.allowedValues(...) without default as required", () => {
+    const template = `pipeline:
+  variables:
+    - name: "region"
+      type: "String"
+      value: "<+input>.allowedValues(us-east-1,eu-west-1)"
+`;
+    const result = substituteInputs(template, {});
+
+    expect(result.unmatchedRequired).toContain("region");
+    expect(result.unmatchedOptional).toHaveLength(0);
+  });
+
+  it("classifies <+input>.default(...).allowedValues(...) as optional", () => {
+    const result = substituteInputs(DEFAULTS_ONLY_TEMPLATE_YAML, {});
+
+    expect(result.unmatchedRequired).toHaveLength(0);
+    expect(result.unmatchedOptional).toHaveLength(3);
+    expect(result.unmatchedOptional).toContain("JAVA_BUILD");
+    expect(result.unmatchedOptional).toContain("PYTHON_BUILD");
+    expect(result.unmatchedOptional).toContain("NPM_BUILD");
+  });
+
+  it("still substitutes optional fields when values provided", () => {
+    const result = substituteInputs(DEFAULTS_ONLY_TEMPLATE_YAML, {
+      JAVA_BUILD: "false",
+    });
+
+    expect(result.matched).toContain("java_build");
+    expect(result.unmatchedOptional).toHaveLength(2);
+    expect(result.yaml).toContain("false");
+  });
+
+  it("returns expectedKeys for all placeholders", () => {
+    const result = substituteInputs(SAMPLE_TEMPLATE_YAML, {});
+
+    expect(result.expectedKeys).toContain("branch");
+    expect(result.expectedKeys).toContain("environment");
+    expect(result.expectedKeys).toContain("image");
+    expect(result.expectedKeys).toHaveLength(3);
+  });
+
+  it("returns expectedKeys for mixed required/optional templates", () => {
+    const result = substituteInputs(MIXED_TEMPLATE_YAML, {});
+
+    expect(result.expectedKeys).toContain("repoName");
+    expect(result.expectedKeys).toContain("build");
+    expect(result.expectedKeys).toContain("SERVICE_LIST");
+    expect(result.expectedKeys).toContain("DEPLOY");
+    expect(result.expectedKeys).toContain("HAR_REGISTRY");
+    expect(result.expectedKeys).toHaveLength(5);
+  });
+
+  it("handles mixed match: some provided, rest split into required/optional", () => {
+    const result = substituteInputs(MIXED_TEMPLATE_YAML, {
+      SERVICE_LIST: "my-service",
+    });
+
+    expect(result.matched).toContain("service_list");
+    expect(result.unmatchedRequired).toContain("repoName");
+    expect(result.unmatchedRequired).toContain("build");
+    expect(result.unmatchedOptional).toContain("DEPLOY");
+    expect(result.unmatchedOptional).toContain("HAR_REGISTRY");
   });
 });
 
@@ -272,7 +384,8 @@ describe("resolveRuntimeInputs", () => {
     );
 
     expect(result.matched).toContain("tag");
-    expect(result.unmatched).toHaveLength(0);
+    expect(result.unmatchedRequired).toHaveLength(0);
+    expect(result.unmatchedOptional).toHaveLength(0);
     expect(result.yaml).toContain("v2.0.0");
     expect(result.yaml).not.toContain("<+input>");
   });
@@ -293,10 +406,11 @@ describe("resolveRuntimeInputs", () => {
     );
 
     expect(result.yaml).toBe("");
-    expect(result.unmatched).toContain("someKey");
+    expect(result.unmatchedRequired).toHaveLength(0);
+    expect(result.unmatchedOptional).toHaveLength(0);
   });
 
-  it("reports unmatched placeholders", async () => {
+  it("reports unmatched required placeholders", async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify({
         status: "SUCCESS",
@@ -312,8 +426,51 @@ describe("resolveRuntimeInputs", () => {
     );
 
     expect(result.matched).toContain("branch");
-    // "environment" and "image" are still unresolved
-    expect(result.unmatched).toContain("environment");
-    expect(result.unmatched).toContain("image");
+    expect(result.unmatchedRequired).toContain("environment");
+    expect(result.unmatchedRequired).toContain("image");
+    expect(result.unmatchedOptional).toHaveLength(0);
+  });
+
+  it("separates required and optional unmatched for mixed templates", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        status: "SUCCESS",
+        data: { inputSetTemplateYaml: MIXED_TEMPLATE_YAML },
+      }), { status: 200, headers: { "Content-Type": "application/json" } }),
+    );
+
+    const client = new HarnessClient(makeConfig());
+    const result = await resolveRuntimeInputs(
+      client,
+      { SERVICE_LIST: "my-svc" },
+      { pipelineId: "mixed_pipe", orgId: "default", projectId: "test-project" },
+    );
+
+    expect(result.matched).toContain("service_list");
+    expect(result.unmatchedRequired).toContain("repoName");
+    expect(result.unmatchedRequired).toContain("build");
+    expect(result.unmatchedOptional).toContain("DEPLOY");
+    expect(result.unmatchedOptional).toContain("HAR_REGISTRY");
+    expect(result.expectedKeys).toHaveLength(5);
+  });
+
+  it("returns all empty arrays when all defaults-only template has no user inputs", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        status: "SUCCESS",
+        data: { inputSetTemplateYaml: DEFAULTS_ONLY_TEMPLATE_YAML },
+      }), { status: 200, headers: { "Content-Type": "application/json" } }),
+    );
+
+    const client = new HarnessClient(makeConfig());
+    const result = await resolveRuntimeInputs(
+      client,
+      {},
+      { pipelineId: "defaults_pipe", orgId: "default", projectId: "test-project" },
+    );
+
+    expect(result.unmatchedRequired).toHaveLength(0);
+    expect(result.unmatchedOptional).toHaveLength(3);
+    expect(result.yaml).toContain("<+input>.default");
   });
 });


### PR DESCRIPTION
## Summary

- **Smart pre-flight validation** in `harness_execute`: before calling the Harness API, validates flat key-value inputs against the pipeline's runtime input template. Blocks execution when required fields (`<+input>`) are missing, while allowing optional fields (`<+input>.default(...)`) to pass through to the API for default handling.
- **Actionable error messages**: when pre-flight blocks, the error includes expected keys, provided keys, structural field hints (e.g. `build` needs a complex object), and dynamically fetched available input sets for the pipeline.
- **LLM guidance improvements**: new `executeHint` on pipeline resource, updated tool descriptions directing LLMs to check `runtime_input_template` first and use `input_set_ids` for complex pipelines (CI codebase build, templates).
- **Bug fix**: `fetchRuntimeInputTemplate` was silently failing for inline pipelines because `orgIdentifier`/`projectIdentifier` weren't injected (the `HarnessClient` only auto-injects `accountIdentifier`). Fixed by falling back to `registry.defaultOrgId`/`defaultProjectId`.

## Motivation

Users reported needing 6+ iterations for the LLM to figure out pipeline runtime inputs (especially branch overrides on complex CI pipelines). Root causes:
1. No pre-flight validation — wrong/missing inputs passed to API, producing cryptic 400 errors
2. No distinction between required and optional placeholders — LLM didn't know which fields to prioritize
3. No guidance to discover inputs or use input sets for complex structures
4. Template fetch was silently failing, bypassing all input resolution logic

## Changes

| File | Change |
|------|--------|
| `src/utils/runtime-input-resolver.ts` | Split `unmatched` into `unmatchedRequired`/`unmatchedOptional` using `<+input>.default()` detection; add `expectedKeys` to `ResolutionResult` |
| `src/tools/harness-execute.ts` | Smart pre-flight: block on required mismatches, skip when `input_set_ids` present, allow optional-only through; fetch input set hints; surface `_inputResolution` metadata; structural field detection |
| `src/registry/toolsets/pipelines.ts` | Updated `actionDescription`, `bodySchema` descriptions, added `executeHint` |
| `src/registry/types.ts` | Added `executeHint?: string` to `ResourceDefinition` |
| `src/registry/index.ts` | Exposed `defaultOrgId`/`defaultProjectId` getters |
| `src/tools/harness-describe.ts` | Surface `executeHint` in describe output |
| `tests/utils/runtime-input-resolver.test.ts` | 10 new tests: required/optional classification, expectedKeys, allowedValues, mixed templates |
| `tests/tools/tool-handlers.test.ts` | 5 new tests: pre-flight blocking/skipping/allowing, success metadata, structural field hints |

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 378 tests pass (15 new)
- [x] Live test: `harness_describe(resource_type="pipeline")` shows `executeHint`
- [x] Live test: `harness_execute` with wrong keys on `service_account_manager` → pre-flight blocks with clear error listing expected keys
- [x] Live test: `harness_execute` with correct keys → pipeline executes, response includes `_inputResolution` metadata


Made with [Cursor](https://cursor.com)