### PR TITLE
fix: validate required body fields on wrapped payload for project/org create

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -245,10 +245,22 @@ export class Registry {
     // Build body
     const body = spec.bodyBuilder ? spec.bodyBuilder(input) : undefined;
 
-    // Validate required fields if bodySchema is defined
+    // Validate required fields if bodySchema is defined.
+    // Body builders for v1 APIs often wrap payloads (e.g. { project: { identifier, name } }).
+    // Validate against the inner object when body is a single-key wrapper.
     if (spec.bodySchema && body && typeof body === "object") {
+      const bodyRecord = body as Record<string, unknown>;
+      const keys = Object.keys(bodyRecord);
+      const singleKey = keys.length === 1 ? keys[0] : undefined;
+      const inner =
+        singleKey !== undefined &&
+        bodyRecord[singleKey] !== null &&
+        typeof bodyRecord[singleKey] === "object"
+          ? (bodyRecord[singleKey] as Record<string, unknown>)
+          : null;
+      const payload = inner !== null ? inner : bodyRecord;
       const missing = spec.bodySchema.fields
-        .filter(f => f.required && (body as Record<string, unknown>)[f.name] === undefined)
+        .filter(f => f.required && payload[f.name] === undefined)
         .map(f => f.name);
       if (missing.length > 0) {
         throw new Error(


### PR DESCRIPTION
## Problem
`harness_create` with `resource_type: "project"` and `body: { identifier: "test", name: "test" }` failed with:
`Missing required fields for project: identifier, name`

## Cause
- The project create body builder wraps the payload for the v1 API: `buildProjectBody()` turns `{ identifier, name }` into `{ project: { identifier, name } }`.
- Validation in `src/registry/index.ts` was checking the **top-level** built body for `identifier` and `name`, but after the body builder those fields live under `body.project`, so they were always reported missing.

## Fix
When the built body is a single-key wrapper (e.g. `{ project: { ... } }` or `{ org: { ... } }`), we now validate required fields on the **inner** object instead of the top-level body. This fixes both project and organization create when callers pass flat `{ identifier, name }` in the body.

## Testing
- No change to API contract; existing create flows (pipeline, service, etc.) are unchanged.
- Project and org create now accept `body: { identifier, name }` and pass validation.