### PR TITLE
docs: document yamlPipeline for pipeline create in schema and tool description

### DIFF
--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -11,9 +11,10 @@ const ngExtractWithInlineStore = (raw: unknown) => {
 };
 
 const pipelineCreateSchema: BodySchema = {
-  description: "Pipeline YAML definition",
+  description: "Pipeline definition. Prefer yamlPipeline (YAML string) to avoid serialization issues; pipeline (JSON object) is also supported.",
   fields: [
-    { name: "pipeline", type: "object", required: true, description: "Pipeline object with name, identifier, and stages", fields: [
+    { name: "yamlPipeline", type: "string", required: false, description: "Full pipeline YAML string including the 'pipeline:' root. Recommended when creating from generated or edited YAML." },
+    { name: "pipeline", type: "object", required: false, description: "Pipeline as JSON object (name, identifier, stages, etc.). Use yamlPipeline instead when passing YAML to avoid large nested JSON.", fields: [
       { name: "name", type: "string", required: true, description: "Pipeline display name" },
       { name: "identifier", type: "string", required: true, description: "Unique pipeline identifier" },
       { name: "stages", type: "array", required: false, description: "Pipeline stages", itemType: "stage object" },

--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -11,7 +11,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
   server.registerTool(
     "harness_create",
     {
-      description: "Create a new Harness resource. You can pass a Harness URL to auto-extract org and project scope. For pipelines, templates, and triggers — read the schema resource first (e.g. schema:///pipeline) to understand the required body format.",
+      description: "Create a new Harness resource. You can pass a Harness URL to auto-extract org and project scope. For pipelines: pass body as { yamlPipeline: '<full pipeline YAML string>' } (recommended) or { pipeline: { ... } }. Use harness_describe(resource_type='pipeline') to see the full create body schema.",
       inputSchema: {
         resource_type: z.string().describe("The type of resource to create (e.g. pipeline, service, environment, connector, trigger)"),
         body: z.record(z.string(), z.unknown()).describe("The resource definition body (varies by resource type — typically the YAML or JSON spec)"),


### PR DESCRIPTION
## Problem
When creating a pipeline via `harness_create`, agents may pass `body: { pipeline: { ... } }` (nested JSON). That can cause serialization issues and the Harness API may return "Missing required fields for pipeline: pipeline". The create `bodyBuilder` already accepts `body.yamlPipeline` (YAML string) and sends it successfully, but the schema and tool description did not document it.

## Solution
- **Pipeline create bodySchema** (`pipelines.ts`): Add `yamlPipeline` (string) as a documented, recommended option. Describe that `pipeline` (JSON object) is also supported but `yamlPipeline` avoids serialization issues. Both fields are now optional in the schema so `harness_describe` exposes the recommended format.
- **`harness_create` tool description**: State that for pipelines, pass `body` as `{ yamlPipeline: '<full pipeline YAML string>' }` (recommended) or `{ pipeline: { ... } }`, and point to `harness_describe` for the full schema.

Agents and skills (e.g. harness-skills create-pipeline) can now discover the yamlPipeline format without relying on skill docs alone.