### PR TITLE
Pull request 64 intent

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -245,10 +245,19 @@ export class Registry {
     // Build body
     const body = spec.bodyBuilder ? spec.bodyBuilder(input) : undefined;
 
-    // Validate required fields if bodySchema is defined
+    // Validate required fields if bodySchema is defined.
+    // When bodyWrapperKey is set, the bodyBuilder wraps user fields inside that
+    // key (e.g. { project: { identifier, name } }), so we validate the inner object.
     if (spec.bodySchema && body && typeof body === "object") {
+      const bodyRecord = body as Record<string, unknown>;
+      const payload =
+        spec.bodyWrapperKey &&
+        bodyRecord[spec.bodyWrapperKey] != null &&
+        typeof bodyRecord[spec.bodyWrapperKey] === "object"
+          ? (bodyRecord[spec.bodyWrapperKey] as Record<string, unknown>)
+          : bodyRecord;
       const missing = spec.bodySchema.fields
-        .filter(f => f.required && (body as Record<string, unknown>)[f.name] === undefined)
+        .filter(f => f.required && payload[f.name] === undefined)
         .map(f => f.name);
       if (missing.length > 0) {
         throw new Error(

--- a/src/registry/toolsets/platform.ts
+++ b/src/registry/toolsets/platform.ts
@@ -181,6 +181,7 @@ export const platformToolset: ToolsetDefinition = {
           responseExtractor: v1Unwrap("org"),
           description: "Create a new organization",
           bodySchema: orgCreateSchema,
+          bodyWrapperKey: "org",
         },
         update: {
           method: "PUT",
@@ -190,6 +191,7 @@ export const platformToolset: ToolsetDefinition = {
           responseExtractor: v1Unwrap("org"),
           description: "Update an existing organization",
           bodySchema: orgUpdateSchema,
+          bodyWrapperKey: "org",
         },
         delete: {
           method: "DELETE",
@@ -243,6 +245,7 @@ export const platformToolset: ToolsetDefinition = {
           responseExtractor: v1Unwrap("project"),
           description: "Create a new project in an organization",
           bodySchema: projectCreateSchema,
+          bodyWrapperKey: "project",
         },
         update: {
           method: "PUT",
@@ -252,6 +255,7 @@ export const platformToolset: ToolsetDefinition = {
           responseExtractor: v1Unwrap("project"),
           description: "Update an existing project",
           bodySchema: projectUpdateSchema,
+          bodyWrapperKey: "project",
         },
         delete: {
           method: "DELETE",

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -84,6 +84,12 @@ export interface EndpointSpec {
   description?: string;
   /** Optional body schema for write operations — exposed via harness_describe */
   bodySchema?: BodySchema;
+  /**
+   * When the bodyBuilder wraps user fields inside a single key
+   * (e.g. `{ project: { identifier, name } }`), set this to the wrapper key
+   * so required-field validation checks the inner object, not the wrapper.
+   */
+  bodyWrapperKey?: string;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Introduce `bodyWrapperKey` to explicitly guide validation for API payloads wrapped by `bodyBuilder`.

This fixes "missing required fields" errors for project and organization creation/update. Previously, the validation incorrectly checked the top-level of the API payload (e.g., `{ project: { identifier: "foo" } }`) for fields like `identifier`, which are actually nested. The `bodyWrapperKey` now explicitly tells the validator to look inside the specified wrapper key.

---
<p><a href="https://cursor.com/agents/bc-e2be871f-87c8-496a-a451-5b94f219735f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2be871f-87c8-496a-a451-5b94f219735f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->