### PR TITLE
PR 65 review

### DIFF
--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -11,9 +11,10 @@ const ngExtractWithInlineStore = (raw: unknown) => {
 };
 
 const pipelineCreateSchema: BodySchema = {
-  description: "Pipeline YAML definition",
+  description: "Pipeline definition. Prefer yamlPipeline (YAML string) to avoid serialization issues; pipeline (JSON object) is also supported.",
   fields: [
-    { name: "pipeline", type: "object", required: true, description: "Pipeline object with name, identifier, and stages", fields: [
+    { name: "yamlPipeline", type: "string", required: false, description: "Full pipeline YAML string including the 'pipeline:' root. Recommended when creating from generated or edited YAML." },
+    { name: "pipeline", type: "object", required: false, description: "Pipeline as JSON object (name, identifier, stages, etc.). Use yamlPipeline instead when passing YAML to avoid large nested JSON.", fields: [
       { name: "name", type: "string", required: true, description: "Pipeline display name" },
       { name: "identifier", type: "string", required: true, description: "Unique pipeline identifier" },
       { name: "stages", type: "array", required: false, description: "Pipeline stages", itemType: "stage object" },
@@ -77,7 +78,10 @@ export const pipelinesToolset: ToolsetDefinition = {
             if (b && typeof b === "object" && typeof b.yamlPipeline === "string") {
               return b.yamlPipeline;
             }
-            return input.body;
+            if (b && typeof b === "object" && b.pipeline !== undefined) {
+              return input.body;
+            }
+            throw new Error("body must include either yamlPipeline (YAML string) or pipeline (JSON object)");
           },
           responseExtractor: ngExtractWithInlineStore,
           description: "Create a new pipeline from YAML",

--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -11,7 +11,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
   server.registerTool(
     "harness_create",
     {
-      description: "Create a new Harness resource. You can pass a Harness URL to auto-extract org and project scope. For pipelines, templates, and triggers — read the schema resource first (e.g. schema:///pipeline) to understand the required body format.",
+      description: "Create a new Harness resource. You can pass a Harness URL to auto-extract org and project scope. For pipelines: pass body as { yamlPipeline: '<full pipeline YAML string>' } (recommended) or { pipeline: { ... } }. For other resource types, use harness_describe(resource_type='...') to see the required body format.",
       inputSchema: {
         resource_type: z.string().describe("The type of resource to create (e.g. pipeline, service, environment, connector, trigger)"),
         body: z.record(z.string(), z.unknown()).describe("The resource definition body (varies by resource type — typically the YAML or JSON spec)"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents the `yamlPipeline` path for pipeline creation, adds validation to the create body builder, and enhances the `harness_create` tool description to guide agents more effectively.

The `yamlPipeline` path was already supported but not discoverable by agents through the schema, leading to potential serialization issues. The added validation guard prevents confusing API errors when agents provide empty or malformed bodies, aligning the create builder with the update builder's robustness. The tool description now explicitly guides agents on using `yamlPipeline` for pipelines while retaining generic guidance for other resource types.

---
<p><a href="https://cursor.com/agents/bc-67660d9f-133b-41f2-817e-b90d8a31bdae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67660d9f-133b-41f2-817e-b90d8a31bdae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->