### PR TITLE
review(#155): harden documentation toolset — 4 fixes for auth leak, missing guard, search noise, empty question

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,10 @@ PORT=3000
 # When true, write/delete/execute operations proceed without user confirmation
 HARNESS_SKIP_ELICITATION=false
 
+# Documentation chatbot — optional, enables harness_search(resource_types=['documentation'])
+# HARNESS_CHATBOT_BASE_URL=https://your-chatbot-endpoint.example.com
+
 # Toolset filtering — comma-separated list of enabled toolsets
 # If unset, all toolsets are enabled
-# Available: pipelines,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto
+# Available: pipelines,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto,documentation
 HARNESS_TOOLSETS=

--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -82,17 +82,16 @@ export class HarnessClient {
 
     const method = options.method ?? "GET";
     const url = this.buildUrl(options);
-    const isFme = options.product === "fme";
+    const isExternalProduct = options.product === "fme" || options.product === "chatbot";
     const headers: Record<string, string> = {
-      "Harness-Account": this.accountId,
+      ...(isExternalProduct ? {} : { "Harness-Account": this.accountId }),
       ...options.headers,
     };
 
-    // Only inject x-api-key when the caller hasn't already set auth.
-    // When service-routing handles auth (bearer-jwt, remote-mcp), it sets
-    // Authorization directly — sending x-api-key alongside would cause
-    // downstream services to attempt API-key validation on the dummy token.
-    if (!headers["Authorization"] && !headers["x-api-key"]) {
+    // Only inject x-api-key for Harness-native requests.
+    // External products (FME, chatbot) manage their own auth via
+    // product-specific headers set in the registry dispatch layer.
+    if (!isExternalProduct && !headers["Authorization"] && !headers["x-api-key"]) {
       headers["x-api-key"] = this.token;
     }
 
@@ -240,14 +239,14 @@ export class HarnessClient {
 
     const method = options.method ?? "POST";
     const url = this.buildUrl(options);
-    const isFme = options.product === "fme";
+    const isExternalProduct = options.product === "fme" || options.product === "chatbot";
     const headers: Record<string, string> = {
-      "Harness-Account": this.accountId,
+      ...(isExternalProduct ? {} : { "Harness-Account": this.accountId }),
       ...options.headers,
     };
 
     // Same auth-header guard as request() — see comment there.
-    if (!headers["Authorization"] && !headers["x-api-key"]) {
+    if (!isExternalProduct && !headers["Authorization"] && !headers["x-api-key"]) {
       headers["x-api-key"] = this.token;
     }
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -53,8 +53,8 @@ export interface RequestOptions {
   timeoutMs?: number;
   /** Return raw ArrayBuffer instead of parsing JSON. Used for binary endpoints (ZIP downloads). */
   responseType?: "json" | "buffer";
-  /** Product backend — when "fme", skips Harness-specific auth/headers/params. */
-  product?: "harness" | "fme";
+  /** Product backend — when "fme"/"chatbot", skips Harness-specific auth/headers/params. */
+  product?: "harness" | "fme" | "chatbot";
   /** When true, omit the automatic `accountIdentifier` query param.
    *  Some APIs (e.g. SEI) use only the `Harness-Account` header for account scoping. */
   headerBasedScoping?: boolean;

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ const RawConfigSchema = z.object({
   HARNESS_SKIP_ELICITATION: z.coerce.boolean().default(false),
   HARNESS_ALLOW_HTTP: z.coerce.boolean().default(false),
   HARNESS_FME_BASE_URL: z.string().url().default("https://api.split.io"),
+  HARNESS_CHATBOT_BASE_URL: z.string().url().optional(),
 });
 
 export const ConfigSchema = RawConfigSchema.transform((data) => {
@@ -60,11 +61,13 @@ const FME_BASE_URL = "https://api.split.io";
 
 /**
  * Resolve the base URL for a given product backend.
- * - "harness" → undefined (uses the default client base URL)
- * - "fme"     → https://api.split.io
+ * - "harness"  → undefined (uses the default client base URL)
+ * - "fme"      → https://api.split.io
+ * - "chatbot"  → HARNESS_CHATBOT_BASE_URL (undefined when not configured)
  */
-export function resolveProductBaseUrl(_config: Config, product: "harness" | "fme"): string | undefined {
+export function resolveProductBaseUrl(_config: Config, product: "harness" | "fme" | "chatbot"): string | undefined {
   if (product === "fme") return FME_BASE_URL;
+  if (product === "chatbot") return _config.HARNESS_CHATBOT_BASE_URL;
   return undefined;
 }
 

--- a/src/registry/extractors.ts
+++ b/src/registry/extractors.ts
@@ -303,3 +303,22 @@ export const fmeGetExtract = (raw: unknown): unknown => {
   }
   return raw;
 };
+
+// ---------------------------------------------------------------------------
+// Documentation chatbot extractors
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps the chatbot's response into the standard list format
+ * so harness_search and harness_list can display it uniformly.
+ * Preserves the full response object (answer + sources) when present.
+ */
+export const chatbotResponseExtract = (raw: unknown): { items: unknown[]; total: number } => {
+  if (typeof raw === "string") {
+    return { items: [{ answer: raw }], total: 1 };
+  }
+  if (typeof raw === "object" && raw !== null && "answer" in raw) {
+    return { items: [raw], total: 1 };
+  }
+  return { items: [{ answer: JSON.stringify(raw) }], total: 1 };
+};

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -35,6 +35,7 @@ import { visualizationsToolset } from "./toolsets/visualizations.js";
 import { governanceToolset } from "./toolsets/governance.js";
 import { freezeToolset } from "./toolsets/freeze.js";
 import { overridesToolset } from "./toolsets/overrides.js";
+import { documentationToolset } from "./toolsets/documentation.js";
 
 const log = createLogger("registry");
 
@@ -73,6 +74,7 @@ const ALL_TOOLSETS: ToolsetDefinition[] = [
   governanceToolset,
   freezeToolset,
   overridesToolset,
+  documentationToolset,
 ];
 
 /**
@@ -380,7 +382,16 @@ export class Registry {
     // Make request — resolve base URL and auth from product backend
     const product = def.product ?? "harness";
     const baseUrl = resolveProductBaseUrl(this.config, product);
-    const productHeaders: Record<string, string> = { ...spec.headers };
+    if (product === "chatbot" && !baseUrl) {
+      throw new Error(
+        "HARNESS_CHATBOT_BASE_URL is not configured. " +
+        "Set this environment variable to the documentation chatbot endpoint URL to use documentation queries."
+      );
+    }
+    const productHeaders: Record<string, string> = {
+      ...spec.headers,
+      ...(spec.headersBuilder ? spec.headersBuilder(input) : {}),
+    };
     if (product === "fme") {
       productHeaders["Authorization"] = `Bearer ${this.config.HARNESS_API_KEY}`;
     }

--- a/src/registry/toolsets/documentation.ts
+++ b/src/registry/toolsets/documentation.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from "node:crypto";
+import type { ToolsetDefinition, BodySchema } from "../types.js";
+import { chatbotResponseExtract } from "../extractors.js";
+
+const chatbotListSchema: BodySchema = {
+  description: "Question payload for the Harness documentation chatbot",
+  fields: [
+    { name: "question", type: "string", required: true, description: "The question to ask (mapped from search_term/query)" },
+    { name: "chat_history", type: "array", required: false, description: "Previous Q&A pairs for multi-turn context. Each item has 'question' and 'answer' fields.", itemType: "{ question: string, answer: string }" },
+  ],
+};
+
+export const documentationToolset: ToolsetDefinition = {
+  name: "documentation",
+  displayName: "Documentation",
+  description: "Query Harness documentation using the AI-powered documentation chatbot",
+  resources: [
+    {
+      resourceType: "documentation",
+      displayName: "Documentation",
+      description:
+        "Ask questions about Harness products and documentation. " +
+        "Uses the Harness Documentation Bot to retrieve and summarize relevant information from Harness docs. " +
+        "All source links from Harness documentation (https://developer.harness.io/docs) are included in the response. " +
+        "Use harness_search(query='your question', resource_types=['documentation']) for single questions. " +
+        "For follow-up/multi-turn conversations, use harness_list(resource_type='documentation', search_term='your question', filters={conversation_id: '...', chat_history: [...]}).",
+      toolset: "documentation",
+      scope: "account",
+      product: "chatbot",
+      headerBasedScoping: true,
+      diagnosticHint: "If queries fail, ensure HARNESS_CHATBOT_BASE_URL is set in server configuration. The chatbot endpoint must be reachable from the MCP server.",
+      identifierFields: [],
+      listFilterFields: [
+        { name: "question", description: "The question to ask the documentation chatbot" },
+        { name: "chat_history", description: "Array of previous Q&A pairs for conversational context. Each item has 'question' and 'answer' fields." },
+        { name: "conversation_id", description: "Conversation ID for multi-turn context. Passed as X-Conversation-Id header." },
+      ],
+      operations: {
+        list: {
+          method: "POST",
+          path: "/v2/chat",
+          headerBasedScoping: true,
+          bodyBuilder: (input: Record<string, unknown>) => {
+            const question = input.search_term ?? input.query ?? input.search ?? input.question ?? input.name ?? "";
+            if (typeof question === "string" && question.trim().length === 0) {
+              throw new Error(
+                "A non-empty question is required for the documentation chatbot. " +
+                "Use harness_search(query='your question', resource_types=['documentation'])."
+              );
+            }
+            const body: Record<string, unknown> = { question };
+            if (Array.isArray(input.chat_history) && input.chat_history.length > 0) {
+              body.chat_history = input.chat_history;
+            }
+            return body;
+          },
+          bodySchema: chatbotListSchema,
+          headersBuilder: (input: Record<string, unknown>) => {
+            const headers: Record<string, string> = {
+              "X-Request-ID": randomUUID(),
+            };
+            const convId = input.conversation_id;
+            if (typeof convId === "string" && convId.length > 0) {
+              headers["X-Conversation-Id"] = convId;
+            }
+            return headers;
+          },
+          responseExtractor: chatbotResponseExtract,
+          description: "Ask a question to the Harness documentation chatbot",
+        },
+      },
+    },
+  ],
+};

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -34,9 +34,10 @@ export type ToolsetName =
   | "visualizations"
   | "governance"
   | "freeze"
-  | "overrides";
+  | "overrides"
+  | "documentation";
 
-export type ProductName = "harness" | "fme";
+export type ProductName = "harness" | "fme" | "chatbot";
 
 export type OperationName = "list" | "get" | "create" | "update" | "delete";
 
@@ -128,6 +129,8 @@ export interface EndpointSpec {
   bodyBuilder?: (input: Record<string, unknown>) => unknown;
   /** Static headers to merge into the request (e.g. Content-Type override) */
   headers?: Record<string, string>;
+  /** Dynamic headers built per-request from tool input */
+  headersBuilder?: (input: Record<string, unknown>) => Record<string, string>;
   /** For GET: extract the useful part from the raw response */
   responseExtractor?: (raw: unknown) => unknown;
   /** Request binary (ArrayBuffer) response instead of JSON. Used for ZIP download endpoints. */

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -14,6 +14,7 @@ const log = createLogger("search");
 /** Relevance tiers — lower number = more relevant. */
 const RELEVANCE_TIERS: Record<string, number> = {
   pipeline: 1, service: 1, environment: 1, connector: 1, execution: 1,
+  documentation: 2,
   template: 2, trigger: 2, input_set: 2, secret: 2, fme_feature_flag: 2,
   repository: 2, infrastructure: 2,
   // SCS types at tier 2 — same priority as other domain-specific resources
@@ -41,10 +42,13 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
   server.registerTool(
     "harness_search",
     {
-      description: "Search across multiple Harness resource types. Returns results ranked by relevance. Accepts a Harness URL for scope.",
+      description:
+        "Search across multiple Harness resource types. Returns results ranked by relevance. Accepts a Harness URL for scope. " +
+        "For questions about Harness features, concepts, or how-to guides, use resource_types=['documentation'] to query the Harness Documentation Bot — " +
+        "it retrieves answers grounded in official Harness docs (https://developer.harness.io/docs) with source citations.",
       inputSchema: {
         query: z.string().describe("Search term"),
-        resource_types: z.array(z.enum(listableTypes)).describe("Types to search (defaults to all listable)").optional(),
+        resource_types: z.array(z.enum(listableTypes)).describe("Types to search (defaults to all listable). Use ['documentation'] for Harness docs/knowledge questions.").optional(),
         url: z.string().describe("Harness UI URL — auto-extracts org and project").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),

--- a/src/utils/compact.ts
+++ b/src/utils/compact.ts
@@ -9,7 +9,7 @@ const TIMESTAMP_PATTERN = /(?:At|Ts|Time|Date)$/;
 /** Fields to always keep when compacting list items. */
 const IDENTITY_FIELDS = new Set([
   "identifier", "name", "displayName", "description", "slug",
-  "versionLabel", "sha", "title", "message",
+  "versionLabel", "sha", "title", "message", "response", "answer", "sources",
 ]);
 
 const STATUS_FIELDS = new Set([

--- a/tests/registry/documentation.test.ts
+++ b/tests/registry/documentation.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the documentation toolset's custom extractor, bodyBuilder, and headersBuilder.
+ * Per CONTRIBUTING.md, custom responseExtractor and bodyBuilder logic warrants verification.
+ */
+import { describe, it, expect } from "vitest";
+import { chatbotResponseExtract } from "../../src/registry/extractors.js";
+import { documentationToolset } from "../../src/registry/toolsets/documentation.js";
+import type { EndpointSpec } from "../../src/registry/types.js";
+
+const listSpec = documentationToolset.resources[0].operations.list as EndpointSpec;
+
+describe("chatbotResponseExtract", () => {
+  it("wraps a string response", () => {
+    const result = chatbotResponseExtract("Hello world");
+    expect(result).toEqual({ items: [{ answer: "Hello world" }], total: 1 });
+  });
+
+  it("preserves an object with answer field", () => {
+    const raw = { answer: "Use pipelines", sources: ["https://docs.harness.io/pipelines"] };
+    const result = chatbotResponseExtract(raw);
+    expect(result).toEqual({ items: [raw], total: 1 });
+  });
+
+  it("JSON-stringifies unknown object shapes", () => {
+    const raw = { unexpected: "data" };
+    const result = chatbotResponseExtract(raw);
+    expect(result.items).toHaveLength(1);
+    expect((result.items[0] as { answer: string }).answer).toBe(JSON.stringify(raw));
+    expect(result.total).toBe(1);
+  });
+
+  it("handles null by stringifying", () => {
+    const result = chatbotResponseExtract(null);
+    expect(result).toEqual({ items: [{ answer: "null" }], total: 1 });
+  });
+});
+
+describe("documentation bodyBuilder", () => {
+  const bodyBuilder = listSpec.bodyBuilder!;
+
+  it("maps search_term to question", () => {
+    const body = bodyBuilder({ search_term: "how to create a pipeline" }) as Record<string, unknown>;
+    expect(body.question).toBe("how to create a pipeline");
+  });
+
+  it("falls back through query → search → question → name", () => {
+    expect((bodyBuilder({ query: "q1" }) as Record<string, unknown>).question).toBe("q1");
+    expect((bodyBuilder({ search: "s1" }) as Record<string, unknown>).question).toBe("s1");
+    expect((bodyBuilder({ question: "q2" }) as Record<string, unknown>).question).toBe("q2");
+    expect((bodyBuilder({ name: "n1" }) as Record<string, unknown>).question).toBe("n1");
+  });
+
+  it("throws on empty question", () => {
+    expect(() => bodyBuilder({})).toThrow("non-empty question is required");
+    expect(() => bodyBuilder({ search_term: "  " })).toThrow("non-empty question is required");
+  });
+
+  it("includes chat_history when present and non-empty", () => {
+    const history = [{ question: "q1", answer: "a1" }];
+    const body = bodyBuilder({ search_term: "follow-up", chat_history: history }) as Record<string, unknown>;
+    expect(body.chat_history).toEqual(history);
+  });
+
+  it("omits chat_history when empty or absent", () => {
+    const body1 = bodyBuilder({ search_term: "test" }) as Record<string, unknown>;
+    expect(body1.chat_history).toBeUndefined();
+    const body2 = bodyBuilder({ search_term: "test", chat_history: [] }) as Record<string, unknown>;
+    expect(body2.chat_history).toBeUndefined();
+  });
+});
+
+describe("documentation headersBuilder", () => {
+  const headersBuilder = listSpec.headersBuilder!;
+
+  it("always includes X-Request-ID", () => {
+    const headers = headersBuilder({});
+    expect(headers["X-Request-ID"]).toBeDefined();
+    expect(headers["X-Request-ID"].length).toBeGreaterThan(0);
+  });
+
+  it("generates unique X-Request-ID on each call", () => {
+    const h1 = headersBuilder({});
+    const h2 = headersBuilder({});
+    expect(h1["X-Request-ID"]).not.toBe(h2["X-Request-ID"]);
+  });
+
+  it("includes X-Conversation-Id when provided", () => {
+    const headers = headersBuilder({ conversation_id: "conv-123" });
+    expect(headers["X-Conversation-Id"]).toBe("conv-123");
+  });
+
+  it("omits X-Conversation-Id when empty or absent", () => {
+    expect(headersBuilder({})["X-Conversation-Id"]).toBeUndefined();
+    expect(headersBuilder({ conversation_id: "" })["X-Conversation-Id"]).toBeUndefined();
+  });
+});
+
+describe("documentation toolset structure", () => {
+  const resource = documentationToolset.resources[0];
+
+  it("has correct toolset metadata", () => {
+    expect(documentationToolset.name).toBe("documentation");
+    expect(documentationToolset.displayName).toBe("Documentation");
+  });
+
+  it("uses chatbot product and account scope", () => {
+    expect(resource.product).toBe("chatbot");
+    expect(resource.scope).toBe("account");
+  });
+
+  it("uses header-based scoping to avoid leaking accountIdentifier", () => {
+    expect(resource.headerBasedScoping).toBe(true);
+    expect(listSpec.headerBasedScoping).toBe(true);
+  });
+
+  it("has a bodySchema on the list operation", () => {
+    expect(listSpec.bodySchema).toBeDefined();
+    expect(listSpec.bodySchema!.fields.length).toBeGreaterThan(0);
+    const questionField = listSpec.bodySchema!.fields.find(f => f.name === "question");
+    expect(questionField).toBeDefined();
+    expect(questionField!.required).toBe(true);
+  });
+
+  it("has a diagnosticHint", () => {
+    expect(resource.diagnosticHint).toBeDefined();
+    expect(resource.diagnosticHint).toContain("HARNESS_CHATBOT_BASE_URL");
+  });
+
+  it("has no identifier fields (list-only resource)", () => {
+    expect(resource.identifierFields).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Code review of PR #155 (documentation chatbot toolset). The original PR does a good job aligning the feature with repo standards — moving the extractor to shared `extractors.ts`, adding `bodySchema`, fixing auth header injection for external products, adding `diagnosticHint`, `.env.example` entry, and 18 unit tests.

However, I found **4 issues** that would cause problems in production. This PR applies the original PR #155 changes with the following hardening fixes layered on top:

### 1. Guard missing `HARNESS_CHATBOT_BASE_URL` (runtime safety)

When `HARNESS_CHATBOT_BASE_URL` is not set, `resolveProductBaseUrl()` returns `undefined` for the chatbot product. The `buildUrl()` method then falls back to the default Harness base URL (`https://app.harness.io`), silently sending chatbot POST requests to `https://app.harness.io/v2/chat` — which is not a valid endpoint. This would produce confusing 404 errors.

**Fix:** Added an early guard in `executeSpec()` that throws a clear, actionable error when `product === "chatbot"` and no base URL is configured.

### 2. Prevent `accountIdentifier` leaking to external chatbot endpoint (security)

The chatbot is an external service (not Harness-native), but the registry's `executeSpec()` still injects `accountIdentifier` as a query parameter (standard for `scope: "account"`). The `buildUrl()` method also injects it unconditionally. This leaks the Harness account ID to a third-party endpoint.

**Fix:** Added `headerBasedScoping: true` on both the resource definition and the endpoint spec. This tells `buildUrl()` to skip the automatic `accountIdentifier` query param injection, matching the pattern already used by SEI.

### 3. Move `documentation` from tier 1 to tier 2 in search relevance (performance)

The original PR placed `documentation` at tier 1 in `RELEVANCE_TIERS`. Since `harness_search()` with no explicit `resource_types` searches **all** listable types, every general search would hit the chatbot endpoint. When `HARNESS_CHATBOT_BASE_URL` isn't configured, this causes a guaranteed error per search call. Even when configured, it's wasteful — the chatbot is for knowledge questions, not entity searches.

**Fix:** Moved to tier 2. Documentation is still high priority when explicitly requested via `resource_types=['documentation']`, but won't pollute every general search.

### 4. Validate non-empty question in `bodyBuilder` (input validation)

The original `bodyBuilder` falls through to `""` when no query key is present in the input, then sends `{ question: "" }` to the chatbot. The `bodySchema` marks `question` as required, but the bodyBuilder *always* provides it (as an empty string), so the schema validation never catches it.

**Fix:** Added an explicit check in the bodyBuilder that throws when the resolved question is empty/whitespace-only, with a clear message telling the agent how to use the tool correctly.

### What the original PR #155 got right

- Moved `chatbotResponseExtract` from inline to shared `extractors.ts`
- Added `bodySchema` for `harness_describe` discoverability
- Fixed `HarnessClient.request()` and `requestStream()` to skip `x-api-key` and `Harness-Account` for external products
- Added `diagnosticHint` for troubleshooting
- Added `HARNESS_CHATBOT_BASE_URL` to `.env.example`
- Added `headersBuilder` to `EndpointSpec` type for dynamic per-request headers
- Added 18 well-structured unit tests

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass (700 passed, 25 skipped)
- [x] Typecheck passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d26d1458-3bfc-4eaa-88ea-d2fe465498b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d26d1458-3bfc-4eaa-88ea-d2fe465498b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

